### PR TITLE
[Feature] 애플 로그인 중복 클릭 방지

### DIFF
--- a/apps/web/src/pages/auth/hooks/useSocialLogin.ts
+++ b/apps/web/src/pages/auth/hooks/useSocialLogin.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
 import { useKakaoLogin } from '@/features/auth/model';
 
@@ -28,7 +28,24 @@ export const useSocialLogin = () => {
     }
   };
 
+  const isDisabledRef = useRef(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  const preventMultipleClicks = (ms: number) => {
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+    }
+
+    isDisabledRef.current = true;
+    timeoutRef.current = window.setTimeout(() => {
+      isDisabledRef.current = false;
+      timeoutRef.current = null;
+    }, ms);
+  };
+
   const loginWithApple = () => {
+    if (isDisabledRef.current) return;
+    preventMultipleClicks(2000);
     window.location.href = `${APPLE_AUTHORIZE_URL}&state=${window.location.origin}`;
   };
 


### PR DESCRIPTION
## 🛠️ 변경 사항

> 실제로 어떤 작업을 했는지 구체적으로 작성해주세요.

- [ ] UI 수정 (Design)
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug)
- [ ] 리팩토링 (Refactor)
- [x] 성능 개선 (Performance)
- [ ] 테스트 추가 (Chore)
- [ ] 기타:

### 세부 변경 내용

- 애플 로그인 버튼 중복 클릭시 네이티브 로그인이 아닌 웹페이지로 리다이렉트 되는 현상을 해결했습니다.
- 최초 애플 로그인 버튼을 클릭한 뒤 `setTimeout`을 통해 일정 시간(현재 2초)동안 apple authorize url로의 리다이렉트를 막습니다.

## 🔍 관련 이슈

> 관련 이슈를 링크해주세요. ex) close #23, related #23

- close #151 

---

## 📸 스크린샷 / GIF (선택)

> UI 변경이 있다면 첨부해주세요.

| Before | After |
| ------ | ----- |
|        |       |

---

## ⚠️ 주의 사항 / 리뷰 포인트

> 리뷰어가 특히 봐줬으면 하는 부분이나 고민했던 지점을 작성해주세요.

-
- ***

## 🔄 연관 작업

> 후속 작업이나 연관된 PR이 있다면 링크해주세요.

-
-
