### PR TITLE
[Bug] 크루 가입 승인된 후 마이페이지 내정보 API 미호출

### DIFF
--- a/apps/web/src/features/crew-confirm-status/hooks/useConfirmJoinStatus.ts
+++ b/apps/web/src/features/crew-confirm-status/hooks/useConfirmJoinStatus.ts
@@ -7,7 +7,7 @@ import type { ConfirmJoinStatusResult } from '@/features/crew-confirm-status/api
 import { CREW_JOIN_STATUS } from '@/features/crew-join-status/model/crewJoinStatus';
 import type { CrewJoinStatus } from '@/features/crew-join-status/model/types';
 
-import { crewQueries } from '@/shared/queries';
+import { crewQueries, memberQueries } from '@/shared/queries';
 
 export const useConfirmJoinStatus = (status: CrewJoinStatus | null) => {
   const { replace } = useFlow();
@@ -24,10 +24,13 @@ export const useConfirmJoinStatus = (status: CrewJoinStatus | null) => {
       queryClient.removeQueries({
         queryKey: crewQueries.defaultKey,
       });
+      queryClient.invalidateQueries({
+        queryKey: memberQueries.myInfoKey(),
+      });
 
       if (data.ok) {
         const redirectActivity =
-          status === CREW_JOIN_STATUS.JOINED ? 'StorePage' : 'OnboardingPage';
+          status === CREW_JOIN_STATUS.JOINED ? 'HomePage' : 'OnboardingPage';
         replace(redirectActivity, {}, { animate: false });
       } else {
         // TODO: 토스트 처리


### PR DESCRIPTION
## 🛠️ 변경 사항

> 실제로 어떤 작업을 했는지 구체적으로 작성해주세요.

- [ ] UI 수정 (Design)
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug)
- [ ] 리팩토링 (Refactor)
- [ ] 성능 개선 (Performance)
- [ ] 테스트 추가 (Chore)
- [ ] 기타:

### 세부 변경 내용

- 크루 가입 승인됨 확인 후 내정보 데이터의 staletime이 남아 API를 재호출하지 않는 문제를 쿼리키 무효화를 통해 해결했습니다.
- 가입 승인 확인 후 Homepage로 이동되도록 수정했습니다.

## 🔍 관련 이슈

> 관련 이슈를 링크해주세요. ex) close #23, related #23

- close #167 

---

## 📸 스크린샷 / GIF (선택)

> UI 변경이 있다면 첨부해주세요.

| Before | After |
| ------ | ----- |
|        |       |

---

## ⚠️ 주의 사항 / 리뷰 포인트

> 리뷰어가 특히 봐줬으면 하는 부분이나 고민했던 지점을 작성해주세요.

-
- ***

## 🔄 연관 작업

> 후속 작업이나 연관된 PR이 있다면 링크해주세요.

- 라우팅 로직이 흩어져서 라우팅 요구사항 변경에 따라 누락된 변경사항 발생.. 개선 필요(#169)