### PR TITLE
 [Improvement] pre-commit hook 실행 시간 개선

### DIFF
--- a/.commit-types.js
+++ b/.commit-types.js
@@ -6,7 +6,7 @@ module.exports = {
     docs: '📝',
     style: '💄',
     refactor: '♻️',
-    perf: '⚡',
+    perf: '⚡️',
     test: '✅',
     chore: '🔧',
   },

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,19 +1,6 @@
 pre-commit:
   parallel: true
   commands:
-    prettier:
-      run: pnpm prettier
-
-    lint:
-      run: |
-        git diff --cached --name-only \
-          | grep -E '^(apps|packages|tooling)/' \
-          | cut -d/ -f1,2 \
-          | sort -u \
-          | while read -r pkg; do
-              pnpm exec turbo run lint --filter="./$pkg"
-            done
-
     typecheck:
       run: |
         git diff --cached --name-only \
@@ -25,8 +12,19 @@ pre-commit:
             done
 
     format:
-      run: pnpm format
+      glob: "**/*.{js,jsx,ts,tsx,json,md,yaml,yml}"
+      run: |
+        pnpm exec prettier --write {staged_files}
+        echo "{staged_files}" | tr ' ' '\n' \
+          | grep -E '^(apps|packages|tooling)/' \
+          | while read -r file; do
+              pkg=$(echo "$file" | cut -d/ -f1,2)
+              (cd "$pkg" && pnpm exec eslint --fix "${file#$pkg/}") &
+            done
+        wait
       stage_fixed: true
 
 commit-msg:
-  run: pnpm commitlint --edit {1}
+  commands:
+    commitlint:
+      run: pnpm commitlint --edit {1}

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -15,12 +15,17 @@ pre-commit:
       glob: '**/*.{js,jsx,ts,tsx,json,md,yaml,yml}'
       run: |
         pnpm exec prettier --write {staged_files}
-        echo "{staged_files}" | tr ' ' '\n' \
+        for pkg in $(echo "{staged_files}" | tr ' ' '\n' \
           | grep -E '^(apps|packages|tooling)/' \
-          | while read -r file; do
-              pkg=$(echo "$file" | cut -d/ -f1,2)
-              (cd "$pkg" && pnpm exec eslint --fix "${file#$pkg/}") &
-            done
+          | cut -d/ -f1,2 | sort -u); do
+          files=$(echo "{staged_files}" | tr ' ' '\n' \
+            | grep "^$pkg/" \
+            | grep -E "\.(js|jsx|ts|tsx)$" \
+            | sed "s|^$pkg/||")
+          if [ -n "$files" ]; then
+            (cd "$pkg" && echo "$files" | xargs pnpm exec eslint --fix) &
+          fi
+        done
         wait
       stage_fixed: true
 

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -12,7 +12,7 @@ pre-commit:
             done
 
     format:
-      glob: "**/*.{js,jsx,ts,tsx,json,md,yaml,yml}"
+      glob: '**/*.{js,jsx,ts,tsx,json,md,yaml,yml}'
       run: |
         pnpm exec prettier --write {staged_files}
         echo "{staged_files}" | tr ' ' '\n' \

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@ module.exports = {
   parserPreset: {
     parserOpts: {
       headerPattern:
-        /^(?<emoji>[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}])\s\[(?<type>feat|fix|chore|docs|style|refactor|test|perf|rename|remove)\]\s(?<subject>.+)$/u,
+        /^(?<emoji>[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]\u{FE0F}?)\s\[(?<type>feat|fix|chore|docs|style|refactor|test|perf|rename|remove)\]\s(?<subject>.+)$/u,
       headerCorrespondence: ['emoji', 'type', 'subject'],
     },
   },

--- a/turbo.json
+++ b/turbo.json
@@ -9,10 +9,12 @@
       "env": ["MODE", "DEV", "PROD"]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^lint"],
+      "inputs": ["$TURBO_DEFAULT$"]
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"]
+      "dependsOn": ["^typecheck"],
+      "inputs": ["$TURBO_DEFAULT$"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## 🛠️ 변경 사항

> 실제로 어떤 작업을 했는지 구체적으로 작성해주세요.

- [ ] UI 수정 (Design)
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug)
- [ ] 리팩토링 (Refactor)
- [x] 성능 개선 (Performance)
- [ ] 테스트 추가 (Chore)
- [ ] 기타:

### 세부 변경 내용

- `prettier` 태스크 제거 — `format`과 중복 실행
- `lint` 태스크 제거 — `format`의 eslint --fix와 중복 실행
- `turbo.json` lint/typecheck에 `inputs: ["$TURBO_DEFAULT$"]` 추가 — 변경 없는 패키지 캐시 히트
- `format` prettier를 전체 파일 → staged 파일만 실행
- `format` eslint --fix를 staged 파일 단위 병렬 실행
- `commitlint` 정규식에 이모지 variation selector(`️`) 허용

**파일 10개 기준 (캐시 미스) — 약 15배 개선 (28초 → 1.8초)**

| | 변경 전 | 변경 후 |
|---|---|---|
| prettier | 6.51초 | 제거 |
| lint | 10.71초 | 제거 |
| typecheck | 2.92초 | 1.80초 |
| format | 28.00초 | 0.98초 |
| **전체** | **28.02초** | **1.81초** |

## 🔍 관련 이슈

> 관련 이슈를 링크해주세요. ex) close #23, related #23

- close #198 

---

## ⚠️ 주의 사항 / 리뷰 포인트

> 리뷰어가 특히 봐줬으면 하는 부분이나 고민했던 지점을 작성해주세요.

- `format`이 prettier + eslint --fix를 모두 담당하므로 `lint`, `prettier` 태스크는 의도적으로 제거
- eslint는 turbo 없이 파일 단위로 직접 실행 (각 패키지 디렉토리에서 cd 후 실행)