### PR TITLE
[Feature] 마이페이지 UI 개편 및 OAS 타입 마이그레이션

### DIFF
--- a/apps/web/src/entities/crew/api/cancelJoinRequest.ts
+++ b/apps/web/src/entities/crew/api/cancelJoinRequest.ts
@@ -1,6 +1,10 @@
 import { auth } from '@/shared/api/apiClient';
+import type { ApiResponseWithoutResult } from '@/shared/api/baseTypes';
 import { END_POINT } from '@/shared/constants/endpoint';
 
 export const cancelJoinRequest = (crewId: number) => {
-  return auth.delete(END_POINT.CREW.CANCEL_JOIN_REQUEST(crewId));
+  return auth.delete<ApiResponseWithoutResult>(
+    END_POINT.CREW.CANCEL_JOIN_REQUEST(crewId),
+    undefined
+  );
 };

--- a/apps/web/src/entities/crew/api/cancelJoinRequest.ts
+++ b/apps/web/src/entities/crew/api/cancelJoinRequest.ts
@@ -1,0 +1,6 @@
+import { auth } from '@/shared/api/apiClient';
+import { END_POINT } from '@/shared/constants/endpoint';
+
+export const cancelJoinRequest = (crewId: number) => {
+  return auth.delete(END_POINT.CREW.CANCEL_JOIN_REQUEST(crewId));
+};

--- a/apps/web/src/entities/crew/api/deleteJoinRequest.ts
+++ b/apps/web/src/entities/crew/api/deleteJoinRequest.ts
@@ -2,7 +2,7 @@ import { auth } from '@/shared/api/apiClient';
 import type { ApiResponseWithoutResult } from '@/shared/api/baseTypes';
 import { END_POINT } from '@/shared/constants/endpoint';
 
-export const cancelJoinRequest = (crewId: number) => {
+export const deleteJoinRequest = (crewId: number) => {
   return auth.delete<ApiResponseWithoutResult>(
     END_POINT.CREW.CANCEL_JOIN_REQUEST(crewId),
     undefined

--- a/apps/web/src/entities/user/api/getMyCrews.ts
+++ b/apps/web/src/entities/user/api/getMyCrews.ts
@@ -1,0 +1,8 @@
+import { auth } from '@/shared/api/apiClient';
+import { END_POINT } from '@/shared/constants/endpoint';
+
+import type { MyCrewApiResponse } from '@/entities/user/model';
+
+export const getMyCrews = () => {
+  return auth.get<MyCrewApiResponse>(END_POINT.MEMBER.MY_CREWS);
+};

--- a/apps/web/src/entities/user/model/user.model.ts
+++ b/apps/web/src/entities/user/model/user.model.ts
@@ -6,6 +6,7 @@ import type { ScheduleCalendarItem } from '@/shared/types/schedule';
 /** API 스키마 기준 Response 타입만 정의 */
 
 export type MyInfoResponse = components['schemas']['MyInfoResponse'];
+export type MyCrewResponse = components['schemas']['MyCrewResponse'];
 export type LinkedProviderResponse =
   components['schemas']['LinkedProviderResponse'];
 export type CrewMemberListResponse =

--- a/apps/web/src/entities/user/model/user.types.ts
+++ b/apps/web/src/entities/user/model/user.types.ts
@@ -6,16 +6,19 @@ import type {
   CrewMemberListResponse,
   LinkedProviderResponse,
   MyAttendanceResponse,
+  MyCrewResponse,
   MyInfoResponse,
 } from './user.model';
 
-type MyInfoResponseSchema = MyInfoResponse;
+export type MyInfoResult = Required<MyInfoResponse>;
 
-export type MyInfoResult = Required<
-  Omit<MyInfoResponseSchema, 'invitationCode'>
+export type MyCrewResult = Required<
+  Omit<MyCrewResponse, 'memberRole' | 'invitationCode'>
 > & {
+  memberRole: 'LEADER' | 'MEMBER' | null;
   invitationCode: string | null;
 };
+export type MyCrewApiResponse = ApiResponse<MyCrewResult[]>;
 
 export type MyInfoApiResponse = ApiResponse<MyInfoResult>;
 

--- a/apps/web/src/features/crew-confirm-status/hooks/useConfirmJoinStatus.ts
+++ b/apps/web/src/features/crew-confirm-status/hooks/useConfirmJoinStatus.ts
@@ -21,6 +21,9 @@ export const useConfirmJoinStatus = (status: CrewJoinStatus | null) => {
         queryKey: memberQueries.myInfoKey(),
       });
       queryClient.invalidateQueries({
+        queryKey: memberQueries.myCrewsKey(),
+      });
+      queryClient.invalidateQueries({
         queryKey: scheduleQueries.all,
       });
 

--- a/apps/web/src/features/crew-join-status/model/types.ts
+++ b/apps/web/src/features/crew-join-status/model/types.ts
@@ -1,5 +1,3 @@
 import type { CrewJoinStatusResult } from '@/entities/crew/model';
-import type { MyInfoResult } from '@/entities/user/model';
-export type CrewJoinStatus =
-  | CrewJoinStatusResult['status']
-  | MyInfoResult['status'];
+
+export type CrewJoinStatus = CrewJoinStatusResult['status'];

--- a/apps/web/src/pages/crew-join-status/ui/CrewBannedStatusPage.tsx
+++ b/apps/web/src/pages/crew-join-status/ui/CrewBannedStatusPage.tsx
@@ -14,29 +14,22 @@ import { memberQueries } from '@/shared/queries';
 import { AppLayout } from '@/shared/ui/layout';
 
 export function CrewBannedStatusPage() {
-  const { data, isLoading } = useQuery({
-    ...memberQueries.myInfoQuery(),
-    select: (data) => {
-      const result = data.result;
-      if (!result) return null;
-      if (result.status === 'KICKED_PENDING_CONFIRM') {
-        return { ...result, status: CREW_JOIN_STATUS.EXPELLED };
-      }
+  const { data: myCrewsData, isLoading } = useQuery(
+    memberQueries.myCrewsQuery()
+  );
 
-      return result;
-    },
-  });
+  const expelledCrew =
+    myCrewsData?.find((c) => c.memberStatus === 'EXPELLED') ?? null;
+  const status = expelledCrew ? CREW_JOIN_STATUS.EXPELLED : null;
 
-  const { handleJoinStatus } = useConfirmJoinStatus(data ? data.status : null);
+  const { handleJoinStatus } = useConfirmJoinStatus(status);
 
   if (isLoading) {
     return null;
   }
 
-  const { crewName, crewImageUrl } = data ?? {
-    crewName: '',
-    crewImageUrl: null,
-  };
+  const crewName = expelledCrew?.crewName ?? '';
+  const crewImageUrl = expelledCrew?.crewImageUrl ?? null;
   const content = STATUS_CONTENT['EXPELLED'];
 
   return (

--- a/apps/web/src/pages/home/ui/HomePage.tsx
+++ b/apps/web/src/pages/home/ui/HomePage.tsx
@@ -34,8 +34,9 @@ export function HomePage() {
 
   const queryClient = useQueryClient();
 
-  const { data: myInfoData } = useQuery(memberQueries.myInfoQuery());
-  const crewId = myInfoData?.result.crewId ?? 0;
+  const { data: myCrewsData } = useQuery(memberQueries.myCrewsQuery());
+  const crewId =
+    myCrewsData?.find((c) => c.memberStatus === 'JOINED')?.crewId ?? 0;
 
   const { data: scheduleList = [], isLoading } = useQuery({
     ...scheduleQueries.getMemberScheduleListQuery(),

--- a/apps/web/src/pages/mypage/config/menu.ts
+++ b/apps/web/src/pages/mypage/config/menu.ts
@@ -1,8 +1,10 @@
 import type { ActivityName } from '@/app/routes/types';
 
 import { MEMBER_ROLE } from '@/shared/constants/member-role';
-import { KAKAO_INQUIRY_CHAT_URL } from '@/shared/constants/url';
-import { bridge } from '@/shared/lib/bridge';
+import {
+  GOOGLE_FORM_URL,
+  KAKAO_INQUIRY_CHAT_URL,
+} from '@/shared/constants/url';
 import { openExternalUrl } from '@/shared/lib/openExternalUrl';
 import type { MenuGroup } from '@/shared/types/menu';
 
@@ -103,38 +105,8 @@ export const getCrewMenu = (
   ];
 };
 
-const LOCATION_PERMISSION_LABEL: Record<string, string> = {
-  granted: '활성',
-  denied: '비활성',
-};
-
-export const getMypageMenu = (
-  role: MemberRole,
-  crewId: number,
-  push: Push
-): MenuGroup[] => {
+export const getMypageMenu = (push: Push): MenuGroup[] => {
   return [
-    {
-      id: 'authority',
-      title: '권한 관리',
-      items: [
-        {
-          id: 'location-permission',
-          label: '위치 권한 설정',
-          type: 'action',
-          getStatusLabel: async () => {
-            if (!bridge.isNativeMethodAvailable('getLocationPermissionStatus'))
-              return '미설정';
-            const status = await bridge.getLocationPermissionStatus();
-            return LOCATION_PERMISSION_LABEL[status] ?? '미설정';
-          },
-          onAction: async () => {
-            if (!bridge.isNativeMethodAvailable('openLocationSettings')) return;
-            await bridge.openLocationSettings();
-          },
-        },
-      ],
-    },
     {
       id: 'shopping',
       title: '쇼핑 관리',
@@ -160,75 +132,35 @@ export const getMypageMenu = (
       ],
     },
     {
-      id: 'crew',
-      title: '크루 활동',
+      id: 'customer-support',
+      title: '고객 지원',
       items: [
         {
-          id: 'member-management',
-          label: role === MEMBER_ROLE.LEADER ? '멤버 관리' : '멤버 목록',
-          type: 'navigation',
-          onNavigate: () =>
-            push(
-              role === MEMBER_ROLE.LEADER
-                ? 'MemberManagePage'
-                : 'MemberViewPage',
-              { id: crewId },
-              { animate: true }
-            ),
+          id: 'notice',
+          label: '공지사항',
+          type: 'action',
+          onAction: () => {},
         },
         {
-          id: 'my-attendance',
-          label: '출석 로그',
+          id: 'inquiry-support',
+          label: '1:1 문의하기',
           type: 'navigation',
-          onNavigate: () => push('AttendancePage', {}, { animate: true }),
+          onNavigate: () => openExternalUrl(KAKAO_INQUIRY_CHAT_URL),
         },
-      ],
-    },
-    {
-      id: 'policy',
-      title: '약관 및 정책',
-      items: [
         {
-          id: 'terms-of-service',
-          label: '서비스 이용약관',
+          id: 'feedback',
+          label: '의견 남기기',
+          type: 'navigation',
+          onNavigate: () => openExternalUrl(GOOGLE_FORM_URL),
+        },
+        {
+          id: 'policy',
+          label: '약관 및 정책',
           type: 'navigation',
           onNavigate: () =>
             push(
               'TermDetailPage',
               { termType: 'terms-of-service' },
-              { animate: true }
-            ),
-        },
-        {
-          id: 'privacy-policy',
-          label: '개인정보 처리방침',
-          type: 'navigation',
-          onNavigate: () =>
-            push(
-              'TermDetailPage',
-              { termType: 'privacy-policy' },
-              { animate: true }
-            ),
-        },
-        {
-          id: 'location-service-agreement',
-          label: '위치 기반 서비스 이용약관',
-          type: 'navigation',
-          onNavigate: () =>
-            push(
-              'TermDetailPage',
-              { termType: 'location-service-agreement' },
-              { animate: true }
-            ),
-        },
-        {
-          id: 'third-party-info-agreement',
-          label: '제 3자 정보제공 동의 내역',
-          type: 'navigation',
-          onNavigate: () =>
-            push(
-              'TermDetailPage',
-              { termType: 'third-party-info-agreement' },
               { animate: true }
             ),
         },

--- a/apps/web/src/pages/mypage/model/useMypageMenu.ts
+++ b/apps/web/src/pages/mypage/model/useMypageMenu.ts
@@ -2,9 +2,7 @@ import { useFlow } from '@/app/routes/stackflow';
 
 import { getMypageMenu } from '@/pages/mypage/config/menu';
 
-import type { MemberRole } from '@/entities/user/model';
-
-export const useMypageMenu = (role: MemberRole, crewId: number) => {
+export const useMypageMenu = () => {
   const { push } = useFlow();
-  return getMypageMenu(role, crewId, push);
+  return getMypageMenu(push);
 };

--- a/apps/web/src/pages/mypage/styles/MyPage.css.ts
+++ b/apps/web/src/pages/mypage/styles/MyPage.css.ts
@@ -9,24 +9,12 @@ export const mainContainer = style([
   layoutStyles.mainContainer,
   {
     backgroundColor: 'transparent',
-    paddingBottom: '100px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 24,
+    padding: '20px 20px 100px',
   },
 ]);
-
-export const menuSectionWrapper = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 24,
-  width: '100%',
-  padding: '24px 20px 0',
-  backgroundColor: 'transparent',
-});
-
-export const buttonWrapper = style({
-  width: '100%',
-  marginTop: '30px',
-  padding: '0 20px',
-});
 
 export const buttonContainer = style({
   display: 'flex',

--- a/apps/web/src/pages/mypage/ui/CrewPage.tsx
+++ b/apps/web/src/pages/mypage/ui/CrewPage.tsx
@@ -23,29 +23,31 @@ import { BackButton } from '@/shared/ui/button';
 import { AppLayout } from '@/shared/ui/layout';
 import { MenuSection } from '@/shared/ui/menu';
 
-export function CrewPage(_: { params?: { id?: string } }) {
+export function CrewPage({ params }: { params?: { id?: string } }) {
   const [dissolveInput, setDissolveInput] = useState('');
-  const { data: myInfoData, isLoading } = useQuery(memberQueries.myInfoQuery());
 
-  const myInfo = myInfoData?.result;
-  const isLeader = myInfo?.crewMemberRole === MEMBER_ROLE.LEADER;
+  const crewId = Number(params?.id) || 0;
 
-  const menuSections = useCrewMenu(
-    myInfo?.crewMemberRole ?? 'MEMBER',
-    myInfo?.crewId ?? 0
+  const { data: myCrewsData, isLoading } = useQuery(
+    memberQueries.myCrewsQuery()
   );
+  const crew = myCrewsData?.find((c) => c.crewId === crewId) ?? null;
 
-  if (isLoading || !myInfo) return null;
+  const isLeader = crew?.memberRole === MEMBER_ROLE.LEADER;
+
+  const menuSections = useCrewMenu(crew?.memberRole ?? 'MEMBER', crewId);
+
+  if (isLoading || !crew) return null;
 
   const onCopyCode = () => {
-    if (myInfo.invitationCode) {
-      copyToClipboard(myInfo.invitationCode, '초대 코드');
+    if (crew.invitationCode) {
+      copyToClipboard(crew.invitationCode, '초대 코드');
     }
   };
 
   const onShare = async () => {
-    if (myInfo.invitationCode) {
-      await bridge.shareInviteCode(myInfo.invitationCode, myInfo.crewName);
+    if (crew.invitationCode) {
+      await bridge.shareInviteCode(crew.invitationCode, crew.crewName);
     }
   };
 
@@ -61,18 +63,20 @@ export function CrewPage(_: { params?: { id?: string } }) {
               <div className={styles.profileTop}>
                 <div className={styles.avatarWrapper}>
                   <img
-                    src={myInfo.crewImageUrl}
+                    src={crew.crewImageUrl}
                     alt="크루 이미지"
                     className={styles.avatar}
                   />
                   <div className={styles.profileInfo}>
-                    <span className={styles.crewName}>{myInfo.crewName}</span>
-                    <Chip type={ROLE_CHIP_TYPE_MAP[myInfo.crewMemberRole]}>
-                      {MEMBER_ROLE_LABEL[myInfo.crewMemberRole]}
-                    </Chip>
+                    <span className={styles.crewName}>{crew.crewName}</span>
+                    {crew.memberRole && (
+                      <Chip type={ROLE_CHIP_TYPE_MAP[crew.memberRole]}>
+                        {MEMBER_ROLE_LABEL[crew.memberRole]}
+                      </Chip>
+                    )}
                   </div>
                 </div>
-                {myInfo.invitationCode && (
+                {crew.invitationCode && (
                   <div className={styles.inviteCard}>
                     <button
                       type="button"
@@ -80,7 +84,7 @@ export function CrewPage(_: { params?: { id?: string } }) {
                       onClick={onCopyCode}
                     >
                       <span className={styles.inviteCode}>
-                        {myInfo.invitationCode}
+                        {crew.invitationCode}
                       </span>
                       <CopyIcon size={16} />
                     </button>
@@ -114,11 +118,11 @@ export function CrewPage(_: { params?: { id?: string } }) {
                 cancelText="취소하기"
                 actionText="해산하기"
                 actionVariant="danger"
-                actionDisabled={dissolveInput !== myInfo.crewName}
+                actionDisabled={dissolveInput !== crew.crewName}
               >
                 <div className={styles.dissolveInputContainer}>
                   <p className={styles.dissolveInputGuide}>
-                    해산하려면 &apos;{myInfo.crewName}&apos;을 입력해 주세요.
+                    해산하려면 &apos;{crew.crewName}&apos;을 입력해 주세요.
                   </p>
                   <Input
                     placeholder="크루 이름을 정확히 입력해 주세요."

--- a/apps/web/src/pages/mypage/ui/MemberManagePage.tsx
+++ b/apps/web/src/pages/mypage/ui/MemberManagePage.tsx
@@ -34,8 +34,10 @@ export function MemberManagePage({ params }: { params?: { id?: string } }) {
 
   const crewId = Number(params?.id) || 0;
 
-  const { data: myInfoData, isLoading } = useQuery(memberQueries.myInfoQuery());
-  const myInfo = myInfoData?.result ?? null;
+  const { data: myCrewsData, isLoading } = useQuery(
+    memberQueries.myCrewsQuery()
+  );
+  const crew = myCrewsData?.find((c) => c.crewId === crewId) ?? null;
 
   const {
     data: membersData,
@@ -114,11 +116,11 @@ export function MemberManagePage({ params }: { params?: { id?: string } }) {
     },
   });
 
-  if (isLoading || !myInfoData?.result) {
+  if (isLoading || !crew) {
     return <></>;
   }
 
-  const isLeader = myInfo?.crewMemberRole === MEMBER_ROLE.LEADER;
+  const isLeader = crew.memberRole === MEMBER_ROLE.LEADER;
 
   const handleDeleteMember = isLeader
     ? (targetMemberId: number) =>

--- a/apps/web/src/pages/mypage/ui/MyPage.tsx
+++ b/apps/web/src/pages/mypage/ui/MyPage.tsx
@@ -2,7 +2,7 @@ import { vars } from '@azit/design-system';
 import { Header } from '@azit/design-system/header';
 import { SettingsIcon } from '@azit/design-system/icon';
 import { AppScreen } from '@stackflow/plugin-basic-ui';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 import { useFlow } from '@/app/routes/stackflow';
 
@@ -11,16 +11,12 @@ import * as styles from '@/pages/mypage/styles/MyPage.css';
 
 import { MyCrewInfoSection, MyProfileSection } from '@/widgets/mypage/ui';
 
-import { WithdrawButton } from '@/features/auth/ui';
-
 import { memberQueries } from '@/shared/queries';
-import { useAuthStore } from '@/shared/store/auth';
 import { AppLayout } from '@/shared/ui/layout';
 import { MenuSection } from '@/shared/ui/menu';
 import { BottomNavigation } from '@/shared/ui/navigation/BottomNavigation';
 
 export function MyPage() {
-  const { logout } = useAuthStore();
   const { push } = useFlow();
 
   const { data: myInfoData, isLoading } = useQuery(memberQueries.myInfoQuery());
@@ -30,17 +26,6 @@ export function MyPage() {
 
   const myInfo = myInfoData?.result;
   const crews = myCrewsData ?? [];
-
-  const joinedCrew = crews.find((c) => c.memberStatus === 'JOINED') ?? null;
-  const isLeader = joinedCrew?.memberRole === 'LEADER';
-  const joinedCrewId = joinedCrew?.crewId ?? 0;
-
-  const { data: membersData } = useInfiniteQuery({
-    ...memberQueries.crewMembersQuery(joinedCrewId),
-    enabled: isLeader && joinedCrewId > 0,
-  });
-  const memberCount = membersData?.pages[0]?.result?.totalCount ?? 0;
-  const cannotWithdraw = isLeader && memberCount > 1;
 
   const filteredMenu = useMypageMenu();
 

--- a/apps/web/src/pages/mypage/ui/MyPage.tsx
+++ b/apps/web/src/pages/mypage/ui/MyPage.tsx
@@ -2,18 +2,18 @@ import { vars } from '@azit/design-system';
 import { Header } from '@azit/design-system/header';
 import { SettingsIcon } from '@azit/design-system/icon';
 import { AppScreen } from '@stackflow/plugin-basic-ui';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import { useFlow } from '@/app/routes/stackflow';
 
 import { useMypageMenu } from '@/pages/mypage/model/useMypageMenu';
 import * as styles from '@/pages/mypage/styles/MyPage.css';
 
-import { MyProfileSection, MyCrewInfoSection } from '@/widgets/mypage/ui';
+import { MyCrewInfoSection, MyProfileSection } from '@/widgets/mypage/ui';
 
 import { WithdrawButton } from '@/features/auth/ui';
 
-import { crewQueries, memberQueries } from '@/shared/queries';
+import { memberQueries } from '@/shared/queries';
 import { useAuthStore } from '@/shared/store/auth';
 import { AppLayout } from '@/shared/ui/layout';
 import { MenuSection } from '@/shared/ui/menu';
@@ -22,28 +22,40 @@ import { BottomNavigation } from '@/shared/ui/navigation/BottomNavigation';
 export function MyPage() {
   const { logout } = useAuthStore();
   const { push } = useFlow();
+
   const { data: myInfoData, isLoading } = useQuery(memberQueries.myInfoQuery());
-
-  const myInfo = myInfoData?.result;
-  const isLeader = myInfo?.crewMemberRole === 'LEADER';
-
-  const { data: crewInfoData } = useQuery({
-    ...crewQueries.crewInfoQuery(myInfo?.invitationCode ?? ''),
-    enabled: !!myInfo?.invitationCode,
-  });
-
-  const filteredMenu = useMypageMenu(
-    myInfo?.crewMemberRole ?? 'MEMBER',
-    myInfo?.crewId ?? 0
+  const { data: myCrewsData, isLoading: isCrewsLoading } = useQuery(
+    memberQueries.myCrewsQuery()
   );
 
-  if (isLoading || !myInfo) return null;
+  const myInfo = myInfoData?.result;
+  const crews = myCrewsData ?? [];
 
-  const memberCount = crewInfoData?.result.memberCount ?? 0;
-  const cannotWithdraw = isLeader && memberCount !== 1;
+  const joinedCrew = crews.find((c) => c.memberStatus === 'JOINED') ?? null;
+  const isLeader = joinedCrew?.memberRole === 'LEADER';
+  const joinedCrewId = joinedCrew?.crewId ?? 0;
+
+  const { data: membersData } = useInfiniteQuery({
+    ...memberQueries.crewMembersQuery(joinedCrewId),
+    enabled: isLeader && joinedCrewId > 0,
+  });
+  const memberCount = membersData?.pages[0]?.result?.totalCount ?? 0;
+  const cannotWithdraw = isLeader && memberCount > 1;
+
+  const filteredMenu = useMypageMenu();
+
+  if (isLoading || isCrewsLoading || !myInfo) return null;
 
   const navigateToMyProfileEditPage = () => {
     push('MyProfileEditPage', {});
+  };
+
+  const handleNavigateToCrew = (crewId: number) => {
+    push('CrewPage', { id: crewId }, { animate: true });
+  };
+
+  const handleCreateNewCrew = () => {
+    push('OnboardingPage', {}, { animate: true });
   };
 
   return (
@@ -68,32 +80,14 @@ export function MyPage() {
             profile={myInfo}
             navigateToMyProfileEditPage={navigateToMyProfileEditPage}
           />
-          <div className={styles.menuSectionWrapper}>
-            <MyCrewInfoSection
-              crewName={myInfo.crewName}
-              crewImageUrl={myInfo.crewImageUrl}
-              inviteCode={myInfo.invitationCode}
-            />
-            {filteredMenu.map((section) => (
-              <MenuSection key={section.id} section={section} />
-            ))}
-          </div>
-          <div className={styles.buttonWrapper}>
-            <div className={styles.buttonContainer}>
-              <div className={styles.logoutButtonWrapper}>
-                <button
-                  type="button"
-                  className={styles.logoutButton}
-                  onClick={logout}
-                >
-                  로그아웃
-                </button>
-              </div>
-              <div className={styles.withdrawButtonWrapper}>
-                <WithdrawButton cannotWithdraw={cannotWithdraw} />
-              </div>
-            </div>
-          </div>
+          <MyCrewInfoSection
+            crews={crews}
+            onNavigateToCrew={handleNavigateToCrew}
+            onCreateNewCrew={handleCreateNewCrew}
+          />
+          {filteredMenu.map((section) => (
+            <MenuSection key={section.id} section={section} />
+          ))}
         </div>
       </AppLayout>
       <BottomNavigation activeTab="mypage" />

--- a/apps/web/src/pages/schedule/ui/ScheduleCreatePage.tsx
+++ b/apps/web/src/pages/schedule/ui/ScheduleCreatePage.tsx
@@ -37,10 +37,10 @@ export function ScheduleCreatePage({ params }: { params?: { date?: Date } }) {
   );
 
   useEffect(() => {
-    if (myInfoData?.result && !isLeader) {
+    if (joinedCrew && !isLeader) {
       setFormValues((prev) => ({ ...prev, runType: 'LIGHTNING' }));
     }
-  }, [myInfoData, isLeader]);
+  }, [joinedCrew, isLeader]);
 
   const queryClient = useQueryClient();
   const createMutation = useMutation({

--- a/apps/web/src/pages/schedule/ui/ScheduleCreatePage.tsx
+++ b/apps/web/src/pages/schedule/ui/ScheduleCreatePage.tsx
@@ -26,9 +26,11 @@ import { toastError } from '@/shared/ui/toast';
 export function ScheduleCreatePage({ params }: { params?: { date?: Date } }) {
   const { pop, push } = useFlow();
 
-  const { data: myInfoData } = useQuery(memberQueries.myInfoQuery());
-  const crewId = myInfoData?.result.crewId ?? 0;
-  const isLeader = myInfoData?.result.crewMemberRole === MEMBER_ROLE.LEADER;
+  const { data: myCrewsData } = useQuery(memberQueries.myCrewsQuery());
+  const joinedCrew =
+    myCrewsData?.find((c) => c.memberStatus === 'JOINED') ?? null;
+  const crewId = joinedCrew?.crewId ?? 0;
+  const isLeader = joinedCrew?.memberRole === MEMBER_ROLE.LEADER;
 
   const { formValues, setFormValues, validateForm } = useScheduleFormState(
     initializeScheduleFormValues({ params })

--- a/apps/web/src/pages/schedule/ui/ScheduleDetailPage.tsx
+++ b/apps/web/src/pages/schedule/ui/ScheduleDetailPage.tsx
@@ -89,8 +89,9 @@ function ScheduleDetailContent({
   const { push } = useFlow();
   const queryClient = useQueryClient();
 
-  const { data: myInfoData } = useSuspenseQuery(memberQueries.myInfoQuery());
-  const crewId = myInfoData.result.crewId;
+  const { data: myCrewsData } = useSuspenseQuery(memberQueries.myCrewsQuery());
+  const crewId =
+    myCrewsData.find((c) => c.memberStatus === 'JOINED')?.crewId ?? 0;
 
   const { data: scheduleDetailData } = useSuspenseQuery(
     scheduleQueries.scheduleDetailQuery(crewId, scheduleId)

--- a/apps/web/src/pages/schedule/ui/ScheduleEditPage.tsx
+++ b/apps/web/src/pages/schedule/ui/ScheduleEditPage.tsx
@@ -29,9 +29,11 @@ export function ScheduleEditPage({ params }: { params: { id: number } }) {
 
   const queryClient = useQueryClient();
 
-  const { data: myInfoData } = useQuery(memberQueries.myInfoQuery());
-  const crewId = myInfoData?.result.crewId ?? 0;
-  const isLeader = myInfoData?.result.crewMemberRole === MEMBER_ROLE.LEADER;
+  const { data: myCrewsData } = useQuery(memberQueries.myCrewsQuery());
+  const joinedCrew =
+    myCrewsData?.find((c) => c.memberStatus === 'JOINED') ?? null;
+  const crewId = joinedCrew?.crewId ?? 0;
+  const isLeader = joinedCrew?.memberRole === MEMBER_ROLE.LEADER;
 
   const { data: detailData, isLoading } = useQuery({
     ...scheduleQueries.scheduleDetailQuery(crewId, scheduleId),

--- a/apps/web/src/pages/schedule/ui/ScheduleMembersPage.tsx
+++ b/apps/web/src/pages/schedule/ui/ScheduleMembersPage.tsx
@@ -22,8 +22,9 @@ interface ScheduleMembersPageProps {
 export function ScheduleMembersPage({
   params: { id: scheduleId },
 }: ScheduleMembersPageProps) {
-  const { data: myInfoData } = useQuery(memberQueries.myInfoQuery());
-  const crewId = myInfoData?.result.crewId ?? 0;
+  const { data: myCrewsData } = useQuery(memberQueries.myCrewsQuery());
+  const crewId =
+    myCrewsData?.find((c) => c.memberStatus === 'JOINED')?.crewId ?? 0;
 
   const { data: scheduleDetailData } = useQuery({
     ...scheduleQueries.scheduleDetailQuery(crewId, scheduleId),

--- a/apps/web/src/pages/schedule/ui/SchedulePage.tsx
+++ b/apps/web/src/pages/schedule/ui/SchedulePage.tsx
@@ -49,8 +49,9 @@ export function SchedulePage() {
     setActiveFilter(undefined);
   }, [selectedDate]);
 
-  const { data: myInfoData } = useQuery(memberQueries.myInfoQuery());
-  const crewId = myInfoData?.result.crewId ?? 0;
+  const { data: myCrewsData } = useQuery(memberQueries.myCrewsQuery());
+  const crewId =
+    myCrewsData?.find((c) => c.memberStatus === 'JOINED')?.crewId ?? 0;
   const yearMonth = formatDate(viewDate, 'YYYY-MM');
 
   const { data: scheduleList = [], isLoading } = useQuery({

--- a/apps/web/src/shared/api/apiTypes.ts
+++ b/apps/web/src/shared/api/apiTypes.ts
@@ -202,31 +202,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/v1/members/me/confirm-status': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * 가입 승인/거절 및 크루 방출 결과 확인
-     * @description 사용자가 가입 신청 결과(승인/거절) 또는 크루 방출 통보를 확인했음을 서버에 알립니다. <br><br>
-     *
-     *     **[참고 사항]** <br>
-     *     * APPROVED_PENDING_CONFIRM, REJECTED_PENDING_CONFIRM, KICKED_PENDING_CONFIRM 상태인 회원만 호출 가능합니다. (INVALID_MEMBER_STATUS)
-     *     * 가입 승인 확인 (APPROVED_PENDING_CONFIRM): 즉시 ACTIVE로 변경됩니다. <br>
-     *     * 가입 거절/크루 방출 확인 (REJECTED_PENDING_CONFIRM / KICKED_PENDING_CONFIRM): 가입되어 있는 다른 크루가 1개 이상 있는 경우 ACTIVE 상태가 유지되고, 가입되어 있는 다른 크루가 없는 경우 PENDING_ONBOARDING으로 변경됩니다.
-     */
-    post: operations['confirmMemberStatus'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/api/v1/images/presigned-url': {
     parameters: {
       query?: never;
@@ -281,7 +256,7 @@ export interface paths {
      *
      *     **[제약 사항]** <br>
      *     * 크루 이름: 최대 15자 이내로 작성해야 합니다. (INVALID_INPUT_VALUE)
-     *     * 온보딩 단계(PENDING_ONBOARDING) 또는 정회원(ACTIVE) 상태의 사용자만 요청 가능합니다. (INVALID_MEMBER_STATUS)
+     *     * ACTIVE 상태의 사용자만 요청 가능합니다. (INVALID_MEMBER_STATUS)
      */
     post: operations['createCrew'];
     delete?: never;
@@ -936,19 +911,8 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * 내 정보 조회 (마이페이지 및 크루 정보 확인용)
-     * @description 로그인한 사용자의 기본 프로필 정보와 소속(또는 관련) 크루 정보를 조회합니다. <br>
-     *     회원의 현재 상태에 따라 반환되는 크루 정보의 의미가 달라집니다. <br><br>
-     *
-     *     **[상태별 크루 정보 반환 규칙]** <br>
-     *     1. ACTIVE: 가장 최근에 가입한 크루 정보를 반환합니다. <br>
-     *     2. KICKED_PENDING_CONFIRM: 방출 통보 화면을 띄우기 위해, 방금 방출된 크루 정보를 반환합니다. <br>
-     *     3. REJECTED_PENDING_CONFIRM: 가입 거절 안내 화면을 위해, 가장 최근에 가입이 거절된 크루 정보를 반환합니다. <br>
-     *     4. WAITING_FOR_APPROVE: 승인 대기 화면을 위해, 가장 최근에 가입 신청한 크루 정보를 반환합니다. <br>
-     *     5. PENDING_TERMS, PENDING_ONBOARDING, WITHDRAWN: 크루 관련 정보는 모두 null로 반환됩니다. <br><br>
-     *
-     *     **[참고 사항]** <br>
-     *     * invitationCode: 사용자가 해당 크루의 리더이면서 JOINED 상태일 때만 값이 존재하며, 그 외의 경우에는 null로 내려갑니다.
+     * 내 정보 조회 (마이페이지 상단 카드)
+     * @description 로그인한 사용자의 기본 프로필 정보(닉네임, 프로필 이미지, 포인트, 출석 횟수)를 조회합니다. <br>
      */
     get: operations['getMyInfo'];
     put?: never;
@@ -1006,6 +970,34 @@ export interface paths {
      *     * 추후 계정 연동 기능 도입 시 복수의 소셜 로그인이 반환될 수 있습니다.
      */
     get: operations['getLinkedProviders'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/v1/members/me/crews': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 내 크루 목록 조회 (마이페이지)
+     * @description 로그인한 사용자가 가입(JOINED)하거나 승인 대기(REQUESTED) 중인 크루 목록을 조회합니다. <br>
+     *     최대 3개의 크루가 반환되며, 크루가 없으면 빈 배열([])을 반환합니다. <br><br>
+     *
+     *     **[memberStatus 값]** <br>
+     *     * JOINED: 정식 가입 상태. memberRole 이 함께 반환됩니다. <br>
+     *     * REQUESTED: 승인 대기 상태. memberRole 은 null 입니다. <br><br>
+     *
+     *     **[참고 사항]** <br>
+     *     * invitationCode: 사용자가 해당 크루의 리더이면서 JOINED 상태일 때만 값이 존재하며, 그 외의 경우에는 null로 내려갑니다.
+     */
+    get: operations['getMyCrews'];
     put?: never;
     post?: never;
     delete?: never;
@@ -1338,7 +1330,7 @@ export interface paths {
      *     * 해당 크루의 리더(LEADER)만 이 API를 호출할 수 있습니다. (NOT_CREW_LEADER)
      *     * 리더 본인은 스스로를 방출할 수 없습니다. (CANNOT_KICK_SELF)
      *     * 가입 완료(JOINED) 상태인 멤버만 방출 가능합니다. (NOT_A_CREW_MEMBER)
-     *     * 방출 직후 KICKED_PENDING_CONFIRM 상태로 변경됩니다.
+     *     * 방출 후 크루 가입 상태(CrewMemberStatus)가 EXPELLED로 변경됩니다.
      */
     delete: operations['deleteCrewMember'];
     options?: never;
@@ -1749,15 +1741,7 @@ export interface components {
        * @description 회원 상태
        * @enum {string}
        */
-      status?:
-        | 'ACTIVE'
-        | 'WITHDRAWN'
-        | 'PENDING_TERMS'
-        | 'PENDING_ONBOARDING'
-        | 'WAITING_FOR_APPROVE'
-        | 'APPROVED_PENDING_CONFIRM'
-        | 'REJECTED_PENDING_CONFIRM'
-        | 'KICKED_PENDING_CONFIRM';
+      status?: 'ACTIVE' | 'WITHDRAWN' | 'PENDING_TERMS';
       /**
        * Format: int64
        * @description 가입한 크루 ID (없을 경우 null)
@@ -2234,35 +2218,6 @@ export interface components {
       id?: number;
       /** @description 닉네임 */
       nickname?: string;
-      /**
-       * @description 회원 상태
-       * @enum {string}
-       */
-      status?:
-        | 'ACTIVE'
-        | 'WITHDRAWN'
-        | 'PENDING_TERMS'
-        | 'PENDING_ONBOARDING'
-        | 'WAITING_FOR_APPROVE'
-        | 'APPROVED_PENDING_CONFIRM'
-        | 'REJECTED_PENDING_CONFIRM'
-        | 'KICKED_PENDING_CONFIRM';
-      /**
-       * Format: int64
-       * @description 크루 ID
-       */
-      crewId?: number;
-      /** @description 크루 이름 */
-      crewName?: string;
-      /** @description 크루 초대코드 */
-      invitationCode?: string;
-      /** @description 크루 이미지 url */
-      crewImageUrl?: string;
-      /**
-       * @description 크루 내 역할
-       * @enum {string}
-       */
-      crewMemberRole?: 'LEADER' | 'MEMBER';
       /** @description 프로필 이미지 URL */
       profileImageUrl?: string;
       /**
@@ -2344,6 +2299,40 @@ export interface components {
     LinkedProviderResponse: {
       /** @description 연동된 소셜 로그인 목록 */
       providers?: ('KAKAO' | 'APPLE')[];
+    };
+    CommonResponseListMyCrewResponse: {
+      code?: string;
+      message?: string;
+      result?: components['schemas']['MyCrewResponse'][];
+    };
+    MyCrewResponse: {
+      /**
+       * Format: int64
+       * @description 크루 ID
+       */
+      crewId?: number;
+      /** @description 크루 이름 */
+      crewName?: string;
+      /** @description 크루 이미지 URL */
+      crewImageUrl?: string;
+      /**
+       * @description 크루 내 역할
+       * @enum {string}
+       */
+      memberRole?: 'LEADER' | 'MEMBER';
+      /**
+       * @description 크루 가입 상태
+       * @enum {string}
+       */
+      memberStatus?:
+        | 'REQUESTED'
+        | 'JOINED'
+        | 'REJECTED'
+        | 'EXITED'
+        | 'EXPELLED'
+        | 'CANCELLED';
+      /** @description 크루 초대 코드 */
+      invitationCode?: string;
     };
     CheckInStatusResponse: {
       /** @description 오늘 참여할 일정이 있는지 여부 */
@@ -3523,74 +3512,6 @@ export interface operations {
         'application/json': components['schemas']['CheckInRequest'];
       };
     };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          '*/*': components['schemas']['CommonResponseVoid'];
-        };
-      };
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      405: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-    };
-  };
-  confirmMemberStatus: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
     responses: {
       /** @description OK */
       200: {
@@ -5771,6 +5692,74 @@ export interface operations {
         };
         content: {
           '*/*': components['schemas']['CommonResponseLinkedProviderResponse'];
+        };
+      };
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      405: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+    };
+  };
+  getMyCrews: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['CommonResponseListMyCrewResponse'];
         };
       };
       400: {

--- a/apps/web/src/shared/api/models/auth.ts
+++ b/apps/web/src/shared/api/models/auth.ts
@@ -3,9 +3,18 @@ import type { components, operations } from '@/shared/api/apiTypes';
 export type AuthProvider =
   operations['socialLogin']['parameters']['path']['provider'];
 export type SocialLoginRequest = components['schemas']['SocialLoginRequest'];
-export type SocialLoginResult = Required<
-  components['schemas']['SocialLoginResponse']
->;
+type SocialLoginStatusExtended =
+  | NonNullable<components['schemas']['SocialLoginResponse']['status']>
+  | 'PENDING_ONBOARDING'
+  | 'WAITING_FOR_APPROVE'
+  | 'APPROVED_PENDING_CONFIRM'
+  | 'REJECTED_PENDING_CONFIRM'
+  | 'KICKED_PENDING_CONFIRM';
+
+export type SocialLoginResult = Omit<
+  Required<components['schemas']['SocialLoginResponse']>,
+  'status'
+> & { status: SocialLoginStatusExtended };
 export type ReissueTokenResult = Required<
   components['schemas']['SocialLoginResponse']
 >;

--- a/apps/web/src/shared/constants/endpoint.ts
+++ b/apps/web/src/shared/constants/endpoint.ts
@@ -9,6 +9,7 @@ export const END_POINT = {
   },
   MEMBER: {
     MY_INFO: 'members/me',
+    MY_CREWS: 'members/me/crews',
     MY_PROFILE: 'members/me/profile',
     MY_ATTENDANCE: 'members/me/attendances',
     MY_ATTENDANCE_CALENDAR: 'members/me/attendances/calendar',
@@ -31,6 +32,7 @@ export const END_POINT = {
       `crews/${crewId}/join-requests/${targetMemberId}/approve`,
     REJECT_JOIN_REQUEST: (crewId: number, targetMemberId: number) =>
       `crews/${crewId}/join-requests/${targetMemberId}/reject`,
+    CANCEL_JOIN_REQUEST: (crewId: number) => `crews/${crewId}/join-request`,
   },
   STORE: {
     PRODUCTS: 'products',

--- a/apps/web/src/shared/queries/member.ts
+++ b/apps/web/src/shared/queries/member.ts
@@ -7,8 +7,8 @@ import {
 import { postApproveJoinRequest } from '@/features/crew-manage/api/postApproveJoinRequest';
 import { postRejectJoinRequest } from '@/features/crew-manage/api/postRejectJoinRequest';
 
-import { cancelJoinRequest } from '@/entities/crew/api/cancelJoinRequest';
 import { deleteCrewMember } from '@/entities/crew/api/deleteCrewMember';
+import { deleteJoinRequest } from '@/entities/crew/api/deleteJoinRequest';
 import { getCrewJoinRequests } from '@/entities/crew/api/getCrewJoinRequests';
 import { getCrewMembers } from '@/entities/crew/api/getCrewMembers';
 import { getMyAttendance } from '@/entities/user/api/getMyAttendance';
@@ -121,7 +121,7 @@ export const memberQueries = {
   updateMyProfile: mutationOptions({
     mutationFn: updateMyProfile,
   }),
-  cancelJoinRequest: mutationOptions({
-    mutationFn: ({ crewId }: { crewId: number }) => cancelJoinRequest(crewId),
+  deleteJoinRequest: mutationOptions({
+    mutationFn: ({ crewId }: { crewId: number }) => deleteJoinRequest(crewId),
   }),
 };

--- a/apps/web/src/shared/queries/member.ts
+++ b/apps/web/src/shared/queries/member.ts
@@ -7,11 +7,13 @@ import {
 import { postApproveJoinRequest } from '@/features/crew-manage/api/postApproveJoinRequest';
 import { postRejectJoinRequest } from '@/features/crew-manage/api/postRejectJoinRequest';
 
+import { cancelJoinRequest } from '@/entities/crew/api/cancelJoinRequest';
 import { deleteCrewMember } from '@/entities/crew/api/deleteCrewMember';
 import { getCrewJoinRequests } from '@/entities/crew/api/getCrewJoinRequests';
 import { getCrewMembers } from '@/entities/crew/api/getCrewMembers';
 import { getMyAttendance } from '@/entities/user/api/getMyAttendance';
 import { getMyAttendanceCalendar } from '@/entities/user/api/getMyAttendanceCalendar';
+import { getMyCrews } from '@/entities/user/api/getMyCrews';
 import { getMyInfo } from '@/entities/user/api/getMyInfo';
 import { getMyProviders } from '@/entities/user/api/getMyProviders';
 import { updateMyProfile } from '@/entities/user/api/updateMyProfile';
@@ -26,6 +28,7 @@ export const memberQueries = {
     [...memberQueries.all, 'attendance', request] as const,
   listKey: () => [...memberQueries.all] as const,
   myInfoKey: () => [...memberQueries.all, 'my'] as const,
+  myCrewsKey: () => [...memberQueries.all, 'my-crews'] as const,
   myProvidersKey: () => [...memberQueries.all, 'providers'] as const,
   crewMembersKey: (crewId: number) =>
     [...memberQueries.listKey(), 'crew-members', crewId] as const,
@@ -36,6 +39,13 @@ export const memberQueries = {
       queryKey: memberQueries.myInfoKey(),
       queryFn: () => getMyInfo(),
       staleTime: 1000 * 60 * 60 * 3,
+    }),
+  myCrewsQuery: () =>
+    queryOptions({
+      queryKey: memberQueries.myCrewsKey(),
+      queryFn: () => getMyCrews(),
+      staleTime: 1000 * 60 * 60 * 3,
+      select: (data) => data.result ?? [],
     }),
   myProvidersQuery: () =>
     queryOptions({
@@ -110,5 +120,8 @@ export const memberQueries = {
   }),
   updateMyProfile: mutationOptions({
     mutationFn: updateMyProfile,
+  }),
+  cancelJoinRequest: mutationOptions({
+    mutationFn: ({ crewId }: { crewId: number }) => cancelJoinRequest(crewId),
   }),
 };

--- a/apps/web/src/widgets/mypage/styles/MyCrewInfoSection.css.ts
+++ b/apps/web/src/widgets/mypage/styles/MyCrewInfoSection.css.ts
@@ -1,87 +1,159 @@
 import { vars, typography } from '@azit/design-system';
 import { style } from '@vanilla-extract/css';
 
-export const card = style({
+export const section = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
   width: '100%',
+});
+
+export const sectionHeader = style({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '0 4px',
+});
+
+export const sectionTitle = style([
+  typography.body.b2,
+  {
+    color: vars.colors.black,
+  },
+]);
+
+export const newCrewButton = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: 4,
+  backgroundColor: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  padding: 0,
+});
+
+export const newCrewText = style([
+  typography.body.b3,
+  {
+    color: vars.colors.blue60,
+  },
+]);
+
+export const newCrewIcon = style({
+  color: vars.colors.blue60,
+});
+
+export const crewList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+});
+
+export const crewCard = style({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '12px 20px 12px 16px',
   backgroundColor: vars.colors.white,
-  border: `1px solid ${vars.colors.gray10}`,
   borderRadius: 16,
 });
 
-export const cardHeader = style({
+export const crewCardLeft = style({
   display: 'flex',
-  justifyContent: 'center',
+  flexDirection: 'row',
   alignItems: 'center',
   gap: 8,
-  padding: '12px 16px',
+  flex: 1,
+  minWidth: 0,
 });
 
-export const avatar = style({
-  width: 36,
-  height: 36,
+export const crewAvatar = style({
+  width: 44,
+  height: 44,
   borderRadius: '50%',
   backgroundColor: vars.colors.gray10,
   flexShrink: 0,
   objectFit: 'cover',
 });
 
-export const cardFooter = style({
+export const crewInfo = style({
   display: 'flex',
-  borderTop: `1px solid ${vars.colors.gray10}`,
+  flexDirection: 'column',
+  gap: 2,
+  minWidth: 0,
 });
 
 export const crewName = style([
-  typography.body.b2,
+  typography.body.b3,
   {
     color: vars.colors.black,
-    flexShrink: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   },
 ]);
 
-export const crewJoinInfo = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  height: 44,
-  gap: 6,
-});
+export const crewNamePending = style([
+  typography.body.b3,
+  {
+    color: vars.colors.gray60,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+]);
 
-export const tabButton = style({
-  width: '100%',
-  height: '100%',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
+export const roleBadge = style([
+  typography.body.b4,
+  {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '2px 8px',
+    backgroundColor: vars.colors.blue60,
+    borderRadius: 8,
+    color: vars.colors.white,
+    width: 'fit-content',
+  },
+]);
+
+export const pendingBadge = style([
+  typography.body.b4,
+  {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '2px 8px',
+    backgroundColor: vars.colors.gray20,
+    borderRadius: 8,
+    color: vars.colors.gray60,
+    width: 'fit-content',
+  },
+]);
+
+export const iconButton = style({
+  backgroundColor: 'transparent',
+  border: 'none',
   cursor: 'pointer',
-  gap: 6,
-});
-
-export const copyContent = style([
-  crewJoinInfo,
-  {
-    borderRight: `1px solid ${vars.colors.gray10}`,
-    color: vars.colors.gray70,
-    flex: 1,
+  padding: 0,
+  flexShrink: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  selectors: {
+    '&:disabled': {
+      opacity: 0.5,
+    },
   },
-]);
-
-export const iconWrap = style({
-  width: 16,
-  height: 16,
 });
 
-export const copyIcon = style({
-  color: vars.colors.gray40,
+export const chevronIcon = style({
+  color: vars.colors.gray60,
 });
 
-export const shareContent = style([
-  crewJoinInfo,
-  {
-    color: vars.colors.blue60,
-    flex: 1,
-  },
-]);
-
-export const shareIcon = style({
-  color: vars.colors.blue60,
+export const closeIcon = style({
+  color: vars.colors.gray60,
 });

--- a/apps/web/src/widgets/mypage/styles/MyProfileSection.css.ts
+++ b/apps/web/src/widgets/mypage/styles/MyProfileSection.css.ts
@@ -3,49 +3,71 @@ import { style } from '@vanilla-extract/css';
 
 export const container = style({
   display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  gap: 20,
-  width: '100%',
-  padding: '20px 20px 24px',
-  backgroundColor: vars.colors.white,
-});
-
-export const profileRow = style({
-  display: 'flex',
   flexDirection: 'row',
-  gap: 16,
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  width: '100%',
+  padding: '24px 16px',
+  backgroundColor: vars.colors.blue70,
+  borderRadius: 16,
 });
 
 export const avatar = style({
-  width: 64,
-  height: 64,
+  width: 56,
+  height: 56,
   borderRadius: '50%',
-  backgroundColor: vars.colors.gray10,
+  backgroundColor: vars.colors.blue20,
   flexShrink: 0,
   objectFit: 'cover',
 });
 
-export const profileInfo = style({
+export const nicknameRow = style({
   display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'flex-start',
-  justifyContent: 'center',
-  gap: 8,
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: 2,
   flex: 1,
   minWidth: 0,
+  marginLeft: 12,
+  backgroundColor: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  padding: 0,
 });
 
 export const nickname = style([
-  typography.body.b2,
+  typography.body.b1,
   {
-    color: vars.colors.black,
+    color: vars.colors.white,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   },
 ]);
 
-export const statGrid = style({
-  display: 'grid',
-  gridTemplateColumns: '1fr 1fr',
-  gap: 8,
-  width: '100%',
+export const chevron = style({
+  color: vars.colors.white,
+  flexShrink: 0,
 });
+
+export const pointsBadge = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: 4,
+  padding: '6px 10px 6px 8px',
+  backgroundColor: vars.colors.white,
+  borderRadius: 8,
+  flexShrink: 0,
+});
+
+export const pointsIcon = style({
+  flexShrink: 0,
+});
+
+export const pointsValue = style([
+  typography.body.b3,
+  {
+    color: vars.colors.blue80,
+  },
+]);

--- a/apps/web/src/widgets/mypage/ui/MyCrewInfoSection.tsx
+++ b/apps/web/src/widgets/mypage/ui/MyCrewInfoSection.tsx
@@ -20,8 +20,8 @@ export function MyCrewInfoSection({
 }: MyCrewInfoSectionProps) {
   const queryClient = useQueryClient();
 
-  const cancelMutation = useMutation({
-    ...memberQueries.cancelJoinRequest,
+  const deleteMutation = useMutation({
+    ...memberQueries.deleteJoinRequest,
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: memberQueries.myCrewsKey(),
@@ -98,9 +98,9 @@ export function MyCrewInfoSection({
                     type="button"
                     className={styles.iconButton}
                     onClick={() =>
-                      cancelMutation.mutate({ crewId: crew.crewId })
+                      deleteMutation.mutate({ crewId: crew.crewId })
                     }
-                    disabled={cancelMutation.isPending}
+                    disabled={deleteMutation.isPending}
                     aria-label={`${crew.crewName} 가입 신청 취소`}
                   >
                     <XIcon size={20} className={styles.closeIcon} />

--- a/apps/web/src/widgets/mypage/ui/MyCrewInfoSection.tsx
+++ b/apps/web/src/widgets/mypage/ui/MyCrewInfoSection.tsx
@@ -1,63 +1,114 @@
-import { CopyIcon, UploadIcon } from '@azit/design-system/icon';
+import { ChevronRightIcon, PlusIcon, XIcon } from '@azit/design-system/icon';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import * as styles from '@/widgets/mypage/styles/MyCrewInfoSection.css';
 
-import { bridge } from '@/shared/lib/bridge';
-import { copyToClipboard } from '@/shared/lib/clipboard';
+import { memberQueries } from '@/shared/queries';
 
-export interface MyCrewInfoSectionProps {
-  crewName: string;
-  crewImageUrl: string;
-  inviteCode: string | null;
+import type { MyCrewResult } from '@/entities/user/model';
+
+interface MyCrewInfoSectionProps {
+  crews: MyCrewResult[];
+  onNavigateToCrew: (crewId: number) => void;
+  onCreateNewCrew: () => void;
 }
 
 export function MyCrewInfoSection({
-  crewName,
-  crewImageUrl,
-  inviteCode,
+  crews,
+  onNavigateToCrew,
+  onCreateNewCrew,
 }: MyCrewInfoSectionProps) {
-  const onCopyCode = () => {
-    if (inviteCode) {
-      copyToClipboard(inviteCode, '초대 코드');
-    }
-  };
+  const queryClient = useQueryClient();
 
-  const onShare = async () => {
-    if (inviteCode) {
-      await bridge.shareInviteCode(inviteCode, crewName);
-    }
-  };
+  const cancelMutation = useMutation({
+    ...memberQueries.cancelJoinRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: memberQueries.myCrewsKey(),
+      });
+    },
+  });
 
   return (
-    <div className={styles.card}>
-      <div className={styles.cardHeader}>
-        <div>
-          <img
-            src={crewImageUrl}
-            alt="프로필 이미지"
-            className={styles.avatar}
-          />
-        </div>
-        <span className={styles.crewName}>{crewName}</span>
+    <div className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionTitle}>나의 크루</span>
+        <button
+          type="button"
+          className={styles.newCrewButton}
+          onClick={onCreateNewCrew}
+        >
+          <span className={styles.newCrewText}>새로운 크루</span>
+          <PlusIcon size={16} className={styles.newCrewIcon} />
+        </button>
       </div>
-      {inviteCode && (
-        <div className={styles.cardFooter}>
-          <div className={styles.copyContent}>
-            <button onClick={onCopyCode} className={styles.tabButton}>
-              <span>{inviteCode}</span>
-              <span className={styles.iconWrap}>
-                <CopyIcon size={16} className={styles.copyIcon} />
-              </span>
-            </button>
-          </div>
-          <div className={styles.shareContent}>
-            <button onClick={onShare} className={styles.tabButton}>
-              <span>공유하기</span>
-              <span className={styles.iconWrap}>
-                <UploadIcon size={16} className={styles.shareIcon} />
-              </span>
-            </button>
-          </div>
+
+      {crews.length > 0 && (
+        <div className={styles.crewList}>
+          {crews.map((crew) => {
+            const isJoined = crew.memberStatus === 'JOINED';
+            const isRequested = crew.memberStatus === 'REQUESTED';
+
+            if (!isJoined && !isRequested) return null;
+
+            return (
+              <div key={crew.crewId} className={styles.crewCard}>
+                <div className={styles.crewCardLeft}>
+                  {crew.crewImageUrl ? (
+                    <img
+                      src={crew.crewImageUrl}
+                      alt={crew.crewName}
+                      className={styles.crewAvatar}
+                    />
+                  ) : (
+                    <div className={styles.crewAvatar} />
+                  )}
+                  <div className={styles.crewInfo}>
+                    <span
+                      className={
+                        isJoined ? styles.crewName : styles.crewNamePending
+                      }
+                    >
+                      {crew.crewName}
+                    </span>
+                    {isJoined && crew.memberRole ? (
+                      <span className={styles.roleBadge}>
+                        {crew.memberRole === 'LEADER' ? '리더' : '멤버'}
+                      </span>
+                    ) : (
+                      <span className={styles.pendingBadge}>승인 대기중</span>
+                    )}
+                  </div>
+                </div>
+
+                {isJoined ? (
+                  <button
+                    type="button"
+                    className={styles.iconButton}
+                    onClick={() => onNavigateToCrew(crew.crewId)}
+                    aria-label={`${crew.crewName} 크루 페이지로 이동`}
+                  >
+                    <ChevronRightIcon
+                      size={20}
+                      className={styles.chevronIcon}
+                    />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className={styles.iconButton}
+                    onClick={() =>
+                      cancelMutation.mutate({ crewId: crew.crewId })
+                    }
+                    disabled={cancelMutation.isPending}
+                    aria-label={`${crew.crewName} 가입 신청 취소`}
+                  >
+                    <XIcon size={20} className={styles.closeIcon} />
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/apps/web/src/widgets/mypage/ui/MyProfileSection.tsx
+++ b/apps/web/src/widgets/mypage/ui/MyProfileSection.tsx
@@ -1,17 +1,6 @@
-import { Chip } from '@azit/design-system/chip';
-import {
-  CheckCircleBrokenIcon,
-  ChevronRightIcon,
-  CoinsStackedIcon,
-} from '@azit/design-system/icon';
+import { ChevronRightIcon, PointCoinIcon } from '@azit/design-system/icon';
 
 import * as styles from '@/widgets/mypage/styles/MyProfileSection.css';
-import { MypageStatCard } from '@/widgets/mypage/ui/MypageStatCard';
-
-import {
-  MEMBER_ROLE_LABEL,
-  ROLE_CHIP_TYPE_MAP,
-} from '@/shared/constants/member-role';
 
 import type { MyInfoResult } from '@/entities/user/model';
 
@@ -26,43 +15,32 @@ export function MyProfileSection({
 }: MyProfileSectionProps) {
   return (
     <section className={styles.container}>
-      <div className={styles.profileRow}>
-        {profile.profileImageUrl ? (
-          <img
-            src={profile.profileImageUrl}
-            alt={'프로필 이미지'}
-            className={styles.avatar}
-          />
-        ) : (
-          <div
-            className={styles.avatar}
-            role="img"
-            aria-label={profile.nickname}
-          />
-        )}
-        <div className={styles.profileInfo}>
-          <Chip type={ROLE_CHIP_TYPE_MAP[profile.crewMemberRole]}>
-            {MEMBER_ROLE_LABEL[profile.crewMemberRole]}
-          </Chip>
-          <div>
-            <span className={styles.nickname}>{profile.nickname}</span>
-            <button type="button" onClick={navigateToMyProfileEditPage}>
-              <ChevronRightIcon size={20} />
-            </button>
-          </div>
-        </div>
-      </div>
-      <div className={styles.statGrid}>
-        <MypageStatCard
-          label="출석"
-          icon={<CheckCircleBrokenIcon size={20} />}
-          value={profile.totalAttendanceCount}
+      {profile.profileImageUrl ? (
+        <img
+          src={profile.profileImageUrl}
+          alt="프로필 이미지"
+          className={styles.avatar}
         />
-        <MypageStatCard
-          label="포인트"
-          icon={<CoinsStackedIcon size={20} />}
-          value={profile.totalPoints.toLocaleString('ko-KR')}
+      ) : (
+        <div
+          className={styles.avatar}
+          role="img"
+          aria-label={profile.nickname}
         />
+      )}
+      <button
+        type="button"
+        className={styles.nicknameRow}
+        onClick={navigateToMyProfileEditPage}
+      >
+        <span className={styles.nickname}>{profile.nickname}</span>
+        <ChevronRightIcon size={20} className={styles.chevron} />
+      </button>
+      <div className={styles.pointsBadge}>
+        <PointCoinIcon size={20} className={styles.pointsIcon} />
+        <span className={styles.pointsValue}>
+          {profile.totalPoints.toLocaleString('ko-KR')}
+        </span>
       </div>
     </section>
   );

--- a/packages/design-system/src/components/icon/PointCoinIcon.tsx
+++ b/packages/design-system/src/components/icon/PointCoinIcon.tsx
@@ -1,0 +1,46 @@
+import { forwardRef } from 'react';
+import type { Ref } from 'react';
+
+interface PointCoinIconProps {
+  size?: number;
+  className?: string;
+}
+
+function PointCoinIcon(
+  { size = 24, className, ...props }: PointCoinIconProps,
+  ref: Ref<SVGSVGElement>
+) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      ref={ref}
+      className={className}
+      {...props}
+    >
+      <g clipPath="url(#clip0_pointcoin)">
+        <path
+          d="M12 2.25C17.3848 2.25 21.75 6.61522 21.75 12C21.75 17.3848 17.3848 21.75 12 21.75C6.61522 21.75 2.25 17.3848 2.25 12C2.25 6.61522 6.61522 2.25 12 2.25Z"
+          fill="#0366FD"
+          stroke="#B8D4FF"
+          strokeWidth="1.5"
+        />
+        <path
+          d="M12.5403 8.40039H9.60078C9.4351 8.40039 9.30078 8.53471 9.30078 8.70039V15.871C9.30078 16.0367 9.4351 16.171 9.60078 16.171H10.6676C10.8333 16.171 10.9676 16.0367 10.9676 15.871V13.9817C10.9676 13.8161 11.102 13.6817 11.2676 13.6817H12.3112C14.0822 13.6817 15.3008 12.6194 15.3008 11.0359C15.3008 9.44234 14.2692 8.40039 12.5403 8.40039ZM11.8321 12.2857H11.2676C11.102 12.2857 10.9676 12.1514 10.9676 11.9857V10.0856C10.9676 9.91992 11.102 9.78561 11.2676 9.78561H11.8842C12.8524 9.78561 13.5818 10.1397 13.5818 11.0354C13.5818 11.9415 12.8315 12.2857 11.8321 12.2857Z"
+          fill="white"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_pointcoin">
+          <rect width="24" height="24" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}
+
+const ForwardRef = forwardRef(PointCoinIcon);
+export default ForwardRef;

--- a/packages/design-system/src/components/icon/index.ts
+++ b/packages/design-system/src/components/icon/index.ts
@@ -17,6 +17,7 @@ export { default as MarkerPin04Icon } from './MarkerPin04Icon';
 export { default as MapIcon } from './MapIcon';
 export { default as MarkerPinIcon } from './MarkerPinIcon';
 export { default as MinusIcon } from './MinusIcon';
+export { default as PointCoinIcon } from './PointCoinIcon';
 export { default as PlusIcon } from './PlusIcon';
 export { default as SearchIcon } from './SearchIcon';
 export { default as SettingsIcon } from './SettingsIcon';


### PR DESCRIPTION
## 🛠️ 변경 사항

- [x] UI 수정 (Design)
- [x] 기능 추가 (Feature)
- [x] 리팩토링 (Refactor)

### 세부 변경 내용

- **OAS 타입 업데이트**: `MyInfoResponse`에서 크루 관련 필드 제거 반영 (`apiTypes.ts`)
- **나의 크루 API 추가**: `GET /members/me/crews` (`getMyCrews`), `DELETE /crews/{crewId}/join-request` (`cancelJoinRequest`) 엔드포인트 및 `myCrewsQuery` / `cancelJoinRequest` mutation 추가
- **myCrewsQuery 마이그레이션**: `myInfoQuery`에서 크루 필드가 제거됨에 따라 `HomePage`, `SchedulePage`, `ScheduleDetailPage`, `ScheduleEditPage`, `ScheduleCreatePage`, `ScheduleMembersPage`, `CrewBannedStatusPage`, `MemberManagePage`, `CrewPage`, `useConfirmJoinStatus` 에서 `myCrewsQuery` 기반으로 `crewId` 조회하도록 변경
- **마이페이지 UI 개편**: `MyProfileSection`을 블루 카드 디자인(프로필 이미지 + 닉네임 버튼 + 포인트 뱃지)으로 개편, `MyCrewInfoSection`에 JOINED/REQUESTED 크루 목록 및 가입 취소 기능 추가
- **PointCoinIcon 추가**: 피그마 디자인 기반 포인트 코인 아이콘을 디자인 시스템에 등록하고 `CoinsStackedIcon` 대체

***

## 🔍 관련 이슈

- #204

---

## 📸 스크린샷 / GIF (선택)

> UI 변경이 있다면 첨부해주세요.

| Before | After |
| ------ | ----- |
|        |       |

---

## ⚠️ 주의 사항 / 리뷰 포인트

- `myInfoQuery`의 크루 필드가 완전히 제거되었으므로, 크루 관련 데이터가 필요한 곳은 반드시 `myCrewsQuery`를 사용해야 합니다
- `MyCrewInfoSection`에서 `JOINED`, `REQUESTED` 상태의 크루만 렌더링하며, `EXPELLED` 등 나머지 상태는 필터링됩니다

***

## 🔄 연관 작업

-
-