### PR TITLE
[Feature] 크루 해산, 탈퇴 및 초대코드 재발급 기능 구현

### DIFF
--- a/apps/web/src/entities/crew/api/deleteCrew.ts
+++ b/apps/web/src/entities/crew/api/deleteCrew.ts
@@ -1,0 +1,10 @@
+import { auth } from '@/shared/api/apiClient';
+import type { ApiResponseWithoutResult } from '@/shared/api/baseTypes';
+import { END_POINT } from '@/shared/constants/endpoint';
+
+export const deleteCrew = (crewId: number) => {
+  return auth.delete<ApiResponseWithoutResult>(
+    END_POINT.CREW.DISSOLVE(crewId),
+    undefined
+  );
+};

--- a/apps/web/src/entities/crew/api/deleteMyCrewMembership.ts
+++ b/apps/web/src/entities/crew/api/deleteMyCrewMembership.ts
@@ -1,0 +1,10 @@
+import { auth } from '@/shared/api/apiClient';
+import type { ApiResponseWithoutResult } from '@/shared/api/baseTypes';
+import { END_POINT } from '@/shared/constants/endpoint';
+
+export const deleteMyCrewMembership = (crewId: number) => {
+  return auth.delete<ApiResponseWithoutResult>(
+    END_POINT.CREW.EXIT(crewId),
+    undefined
+  );
+};

--- a/apps/web/src/entities/crew/api/postReissueInvitationCode.ts
+++ b/apps/web/src/entities/crew/api/postReissueInvitationCode.ts
@@ -1,0 +1,14 @@
+import { auth } from '@/shared/api/apiClient';
+import type { ApiResponse } from '@/shared/api/baseTypes';
+import { END_POINT } from '@/shared/constants/endpoint';
+
+interface InvitationCodeResult {
+  invitationCode: string;
+}
+
+export const postReissueInvitationCode = (crewId: number) => {
+  return auth.post<ApiResponse<InvitationCodeResult>>(
+    END_POINT.CREW.REISSUE_INVITATION_CODE(crewId),
+    undefined
+  );
+};

--- a/apps/web/src/pages/mypage/config/menu.ts
+++ b/apps/web/src/pages/mypage/config/menu.ts
@@ -21,7 +21,8 @@ export type { MenuItem, MenuGroup } from '@/shared/types/menu';
 export const getCrewMenu = (
   role: MemberRole,
   crewId: number,
-  push: Push
+  push: Push,
+  onReissueInvitationCode?: () => void
 ): MenuGroup[] => {
   const isLeader = role === MEMBER_ROLE.LEADER;
 
@@ -90,13 +91,8 @@ export const getCrewMenu = (
               {
                 id: 'invitation-code-reissue',
                 label: '초대코드 재발급',
-                type: 'navigation' as const,
-                onNavigate: () =>
-                  push(
-                    'InvitationCodeReissuePage' as ActivityName,
-                    {},
-                    { animate: true }
-                  ),
+                type: 'action' as const,
+                onAction: () => onReissueInvitationCode?.(),
               },
             ],
           },

--- a/apps/web/src/pages/mypage/model/useCrewMenu.ts
+++ b/apps/web/src/pages/mypage/model/useCrewMenu.ts
@@ -4,7 +4,11 @@ import { getCrewMenu } from '@/pages/mypage/config/menu';
 
 import type { MemberRole } from '@/entities/user/model';
 
-export const useCrewMenu = (role: MemberRole, crewId: number) => {
+export const useCrewMenu = (
+  role: MemberRole,
+  crewId: number,
+  onReissueInvitationCode?: () => void
+) => {
   const { push } = useFlow();
-  return getCrewMenu(role, crewId, push);
+  return getCrewMenu(role, crewId, push, onReissueInvitationCode);
 };

--- a/apps/web/src/pages/mypage/styles/CrewPage.css.ts
+++ b/apps/web/src/pages/mypage/styles/CrewPage.css.ts
@@ -142,6 +142,32 @@ export const dissolveInputGuide = style([
   },
 ]);
 
+export const reissueCodeGuide = style([
+  typography.body.b3,
+  {
+    color: vars.colors.blue80,
+    textAlign: 'center',
+  },
+]);
+
+export const reissueCodeBox = style({
+  width: '100%',
+  backgroundColor: vars.colors.white,
+  border: `0.5px solid ${vars.colors.gray20}`,
+  borderRadius: 12,
+  height: 48,
+  display: 'flex',
+  alignItems: 'center',
+  padding: '0 16px',
+});
+
+export const reissueCodeText = style([
+  typography.body.b2,
+  {
+    color: vars.colors.black,
+  },
+]);
+
 export const dissolveButton = style([
   typography.body.b4,
   {

--- a/apps/web/src/pages/mypage/ui/CrewPage.tsx
+++ b/apps/web/src/pages/mypage/ui/CrewPage.tsx
@@ -139,7 +139,6 @@ export function CrewPage({ params }: { params?: { id?: string } }) {
             </div>
             {isLeader && crew.invitationCode && (
               <AlertDialog
-                trigger={<span />}
                 title="초대코드 재발급"
                 description={`새로운 초대코드가 생성되며\n기존 초대코드는 더 이상 사용할 수 없어요.`}
                 cancelText="취소하기"

--- a/apps/web/src/pages/mypage/ui/CrewPage.tsx
+++ b/apps/web/src/pages/mypage/ui/CrewPage.tsx
@@ -27,6 +27,7 @@ import { MenuSection } from '@/shared/ui/menu';
 
 export function CrewPage({ params }: { params?: { id?: string } }) {
   const [dissolveInput, setDissolveInput] = useState('');
+  const [isReissueOpen, setIsReissueOpen] = useState(false);
 
   const crewId = Number(params?.id) || 0;
   const { pop } = useFlow();
@@ -39,7 +40,9 @@ export function CrewPage({ params }: { params?: { id?: string } }) {
 
   const isLeader = crew?.memberRole === MEMBER_ROLE.LEADER;
 
-  const menuSections = useCrewMenu(crew?.memberRole ?? 'MEMBER', crewId);
+  const menuSections = useCrewMenu(crew?.memberRole ?? 'MEMBER', crewId, () =>
+    setIsReissueOpen(true)
+  );
 
   const { mutate: dissolveCrew } = useMutation({
     ...memberQueries.dissolveCrew,
@@ -54,6 +57,14 @@ export function CrewPage({ params }: { params?: { id?: string } }) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: memberQueries.myCrewsKey() });
       pop();
+    },
+  });
+
+  const { mutate: reissueInvitationCode } = useMutation({
+    ...memberQueries.reissueInvitationCode,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: memberQueries.myCrewsKey() });
+      setIsReissueOpen(false);
     },
   });
 
@@ -126,6 +137,29 @@ export function CrewPage({ params }: { params?: { id?: string } }) {
                 ))}
               </div>
             </div>
+            {isLeader && crew.invitationCode && (
+              <AlertDialog
+                trigger={<span />}
+                title="초대코드 재발급"
+                description={`새로운 초대코드가 생성되며\n기존 초대코드는 더 이상 사용할 수 없어요.`}
+                cancelText="취소하기"
+                actionText="재발급하기"
+                onAction={() => reissueInvitationCode({ crewId })}
+                open={isReissueOpen}
+                onOpenChange={setIsReissueOpen}
+              >
+                <div className={styles.dissolveInputContainer}>
+                  <p className={styles.reissueCodeGuide}>
+                    현재의 초대 코드는 다음과 같아요
+                  </p>
+                  <div className={styles.reissueCodeBox}>
+                    <span className={styles.reissueCodeText}>
+                      {crew.invitationCode}
+                    </span>
+                  </div>
+                </div>
+              </AlertDialog>
+            )}
             {isLeader ? (
               <AlertDialog
                 trigger={

--- a/apps/web/src/pages/mypage/ui/CrewPage.tsx
+++ b/apps/web/src/pages/mypage/ui/CrewPage.tsx
@@ -5,8 +5,10 @@ import { Header } from '@azit/design-system/header';
 import { CopyIcon, UploadIcon } from '@azit/design-system/icon';
 import { Input } from '@azit/design-system/input';
 import { AppScreen } from '@stackflow/plugin-basic-ui';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+
+import { useFlow } from '@/app/routes/stackflow';
 
 import { useCrewMenu } from '@/pages/mypage/model/useCrewMenu';
 import * as styles from '@/pages/mypage/styles/CrewPage.css';
@@ -27,6 +29,8 @@ export function CrewPage({ params }: { params?: { id?: string } }) {
   const [dissolveInput, setDissolveInput] = useState('');
 
   const crewId = Number(params?.id) || 0;
+  const { pop } = useFlow();
+  const queryClient = useQueryClient();
 
   const { data: myCrewsData, isLoading } = useQuery(
     memberQueries.myCrewsQuery()
@@ -36,6 +40,22 @@ export function CrewPage({ params }: { params?: { id?: string } }) {
   const isLeader = crew?.memberRole === MEMBER_ROLE.LEADER;
 
   const menuSections = useCrewMenu(crew?.memberRole ?? 'MEMBER', crewId);
+
+  const { mutate: dissolveCrew } = useMutation({
+    ...memberQueries.dissolveCrew,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: memberQueries.myCrewsKey() });
+      pop();
+    },
+  });
+
+  const { mutate: exitCrew } = useMutation({
+    ...memberQueries.exitCrew,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: memberQueries.myCrewsKey() });
+      pop();
+    },
+  });
 
   if (isLoading || !crew) return null;
 
@@ -119,6 +139,7 @@ export function CrewPage({ params }: { params?: { id?: string } }) {
                 actionText="해산하기"
                 actionVariant="danger"
                 actionDisabled={dissolveInput !== crew.crewName}
+                onAction={() => dissolveCrew({ crewId })}
               >
                 <div className={styles.dissolveInputContainer}>
                   <p className={styles.dissolveInputGuide}>
@@ -142,6 +163,7 @@ export function CrewPage({ params }: { params?: { id?: string } }) {
                 description={`크루를 나가면 출석 로그와 활동 내역이\n모두 삭제되며 복구할 수 없어요.`}
                 cancelText="취소하기"
                 actionText="나가기"
+                onAction={() => exitCrew({ crewId })}
               />
             )}
           </div>

--- a/apps/web/src/shared/api/apiTypes.ts
+++ b/apps/web/src/shared/api/apiTypes.ts
@@ -93,6 +93,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/v1/test/members/me/withdraw-immediately': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * 사용자 즉시 탈퇴
+     * @description 사용자 탈퇴 및 신규 가입 플로우 테스트를 위한 API입니다. <br>
+     *     실제 탈퇴와 달리 사용자 관련 데이터를 DB에서 즉시 삭제합니다. <br><br>
+     *
+     *     **[참고 사항]** <br>
+     *     * 주문 관련 데이터는 운영과 동일하게 삭제하지 않습니다. (스냅샷 저장 용도) <br><br>
+     */
+    post: operations['forceWithdraw'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/v1/orders': {
     parameters: {
       query?: never;
@@ -1244,6 +1268,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/v1/crews/me': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 가입 완료한 크루 목록 조회
+     * @description 사용자가 가입 완료(JOINED) 상태인 크루 목록을 조회합니다. <br><br>
+     */
+    get: operations['getJoinedCrews'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/v1/crews/invitation/{invitationCode}': {
     parameters: {
       query?: never;
@@ -2253,11 +2297,6 @@ export interface components {
       /** @description 프로필 이미지 URL */
       profileImageUrl?: string;
       /**
-       * Format: int32
-       * @description 누적 출석 횟수
-       */
-      totalAttendanceCount?: number;
-      /**
        * Format: int64
        * @description 포인트
        */
@@ -2777,6 +2816,24 @@ export interface components {
       /** @description 크루 한줄 소개 */
       description?: string;
     };
+    CommonResponseListJoinedCrewResponse: {
+      code?: string;
+      message?: string;
+      result?: components['schemas']['JoinedCrewResponse'][];
+    };
+    JoinedCrewResponse: {
+      /**
+       * Format: int64
+       * @description 크루 ID
+       */
+      crewId?: number;
+      /** @description 크루명 */
+      name?: string;
+      /** @description 크루 이미지 URL */
+      imageUrl?: string;
+      /** @description 크루 한줄 소개 */
+      description?: string;
+    };
     CommonResponseCrewInvitationResponse: {
       code?: string;
       message?: string;
@@ -3251,6 +3308,26 @@ export interface operations {
         };
         content: {
           'application/json': unknown;
+        };
+      };
+    };
+  };
+  forceWithdraw: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['CommonResponseVoid'];
         };
       };
     };
@@ -6357,6 +6434,66 @@ export interface operations {
         };
       };
       400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      405: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+    };
+  };
+  getJoinedCrews: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['CommonResponseListJoinedCrewResponse'];
+        };
+      };
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      401: {
         headers: {
           [name: string]: unknown;
         };

--- a/apps/web/src/shared/constants/endpoint.ts
+++ b/apps/web/src/shared/constants/endpoint.ts
@@ -33,6 +33,8 @@ export const END_POINT = {
     REJECT_JOIN_REQUEST: (crewId: number, targetMemberId: number) =>
       `crews/${crewId}/join-requests/${targetMemberId}/reject`,
     CANCEL_JOIN_REQUEST: (crewId: number) => `crews/${crewId}/join-request`,
+    DISSOLVE: (crewId: number) => `crews/${crewId}`,
+    EXIT: (crewId: number) => `crews/${crewId}/members/me`,
   },
   STORE: {
     PRODUCTS: 'products',

--- a/apps/web/src/shared/constants/endpoint.ts
+++ b/apps/web/src/shared/constants/endpoint.ts
@@ -35,6 +35,8 @@ export const END_POINT = {
     CANCEL_JOIN_REQUEST: (crewId: number) => `crews/${crewId}/join-request`,
     DISSOLVE: (crewId: number) => `crews/${crewId}`,
     EXIT: (crewId: number) => `crews/${crewId}/members/me`,
+    REISSUE_INVITATION_CODE: (crewId: number) =>
+      `crews/${crewId}/invitation-code`,
   },
   STORE: {
     PRODUCTS: 'products',

--- a/apps/web/src/shared/queries/member.ts
+++ b/apps/web/src/shared/queries/member.ts
@@ -7,8 +7,10 @@ import {
 import { postApproveJoinRequest } from '@/features/crew-manage/api/postApproveJoinRequest';
 import { postRejectJoinRequest } from '@/features/crew-manage/api/postRejectJoinRequest';
 
+import { deleteCrew } from '@/entities/crew/api/deleteCrew';
 import { deleteCrewMember } from '@/entities/crew/api/deleteCrewMember';
 import { deleteJoinRequest } from '@/entities/crew/api/deleteJoinRequest';
+import { deleteMyCrewMembership } from '@/entities/crew/api/deleteMyCrewMembership';
 import { getCrewJoinRequests } from '@/entities/crew/api/getCrewJoinRequests';
 import { getCrewMembers } from '@/entities/crew/api/getCrewMembers';
 import { getMyAttendance } from '@/entities/user/api/getMyAttendance';
@@ -123,5 +125,12 @@ export const memberQueries = {
   }),
   deleteJoinRequest: mutationOptions({
     mutationFn: ({ crewId }: { crewId: number }) => deleteJoinRequest(crewId),
+  }),
+  dissolveCrew: mutationOptions({
+    mutationFn: ({ crewId }: { crewId: number }) => deleteCrew(crewId),
+  }),
+  exitCrew: mutationOptions({
+    mutationFn: ({ crewId }: { crewId: number }) =>
+      deleteMyCrewMembership(crewId),
   }),
 };

--- a/apps/web/src/shared/queries/member.ts
+++ b/apps/web/src/shared/queries/member.ts
@@ -13,6 +13,7 @@ import { deleteJoinRequest } from '@/entities/crew/api/deleteJoinRequest';
 import { deleteMyCrewMembership } from '@/entities/crew/api/deleteMyCrewMembership';
 import { getCrewJoinRequests } from '@/entities/crew/api/getCrewJoinRequests';
 import { getCrewMembers } from '@/entities/crew/api/getCrewMembers';
+import { postReissueInvitationCode } from '@/entities/crew/api/postReissueInvitationCode';
 import { getMyAttendance } from '@/entities/user/api/getMyAttendance';
 import { getMyAttendanceCalendar } from '@/entities/user/api/getMyAttendanceCalendar';
 import { getMyCrews } from '@/entities/user/api/getMyCrews';
@@ -132,5 +133,9 @@ export const memberQueries = {
   exitCrew: mutationOptions({
     mutationFn: ({ crewId }: { crewId: number }) =>
       deleteMyCrewMembership(crewId),
+  }),
+  reissueInvitationCode: mutationOptions({
+    mutationFn: ({ crewId }: { crewId: number }) =>
+      postReissueInvitationCode(crewId),
   }),
 };

--- a/packages/design-system/src/components/alert-dialog/AlertDialog.tsx
+++ b/packages/design-system/src/components/alert-dialog/AlertDialog.tsx
@@ -13,6 +13,8 @@ export interface AlertDialogProps {
   children?: ReactNode;
   actionDisabled?: boolean;
   actionVariant?: 'default' | 'danger';
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function AlertDialog({
@@ -26,9 +28,11 @@ export function AlertDialog({
   children,
   actionDisabled = false,
   actionVariant = 'default',
+  open,
+  onOpenChange,
 }: AlertDialogProps) {
   return (
-    <RadixAlertDialog.Root>
+    <RadixAlertDialog.Root open={open} onOpenChange={onOpenChange}>
       <RadixAlertDialog.Trigger asChild>{trigger}</RadixAlertDialog.Trigger>
       <RadixAlertDialog.Portal>
         <RadixAlertDialog.Overlay className={styles.overlay} />

--- a/packages/design-system/src/components/alert-dialog/AlertDialog.tsx
+++ b/packages/design-system/src/components/alert-dialog/AlertDialog.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import * as styles from './AlertDialog.css';
 
 export interface AlertDialogProps {
-  trigger: ReactNode;
+  trigger?: ReactNode;
   title: string;
   description?: string;
   actionText?: string;
@@ -33,7 +33,9 @@ export function AlertDialog({
 }: AlertDialogProps) {
   return (
     <RadixAlertDialog.Root open={open} onOpenChange={onOpenChange}>
-      <RadixAlertDialog.Trigger asChild>{trigger}</RadixAlertDialog.Trigger>
+      {trigger && (
+        <RadixAlertDialog.Trigger asChild>{trigger}</RadixAlertDialog.Trigger>
+      )}
       <RadixAlertDialog.Portal>
         <RadixAlertDialog.Overlay className={styles.overlay} />
         <RadixAlertDialog.Content className={styles.content}>


### PR DESCRIPTION
## 🛠️ 변경 사항

- [x] UI 수정 (Design)
- [x] 기능 추가 (Feature)

### 세부 변경 내용

- 크루 해산 기능 구현 (리더 전용): 크루 이름 입력 확인 후 해산
- 크루 탈퇴 기능 구현 (멤버): 확인 다이얼로그 후 탈퇴
- 초대코드 재발급 기능 구현 (리더 전용): 현재 초대코드를 확인하고 재발급
- `AlertDialog` 컴포넌트에 `open`/`onOpenChange` controlled props 추가
- `deleteCrew`, `deleteMyCrewMembership`, `postReissueInvitationCode` API 함수 추가
- 초대코드 재발급 엔드포인트(`crews/{crewId}/invitation-code`) 추가

---

## 🔍 관련 이슈

- close #205
- related #200

---

## ⚠️ 주의 사항 / 리뷰 포인트

- `AlertDialog`에 `open`/`onOpenChange` prop을 추가해 controlled 모드를 지원하도록 확장했습니다. 초대코드 재발급 모달은 메뉴 `onAction` 콜백으로 트리거되어 AlertDialog 외부에서 상태를 관리합니다.
- 크루 해산/탈퇴 성공 시 `myCrewsKey` 쿼리를 invalidate하고 이전 화면으로 pop합니다.
- 초대코드 재발급 성공 시 `myCrewsKey` 쿼리를 invalidate하여 새 코드가 반영됩니다.
- FSD 레이어 의존성 관련 전체 구조 개선은 #200 에서 별도 진행 예정

---

## 🔄 연관 작업

- #200