### PR TITLE
[Feature] 일정 페이지 헤더 개선 및 목표 페이스 휠 피커 바텀시트 추가

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -64,7 +64,6 @@ conventions:
     util: arrow
   naming:
     constants: BIG_SNAKE_CASE
-    forbid_abbreviation: true
     rest_prefix:
       get: 'get_'
       post: 'post_'

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -57,7 +57,6 @@ util arrow function
 
 2.2 네이밍
 • 상수: BIG_SNAKE_CASE 필수
-• 약어 금지 (btn, cnt, svc 등)
 • REST 함수 Prefix 필수:
 
 HTTP Prefix

--- a/apps/web/src/pages/schedule/ui/SchedulePage.tsx
+++ b/apps/web/src/pages/schedule/ui/SchedulePage.tsx
@@ -100,9 +100,12 @@ export function SchedulePage() {
                 <span className={styles.crewName}>{selectedCrew?.name}</span>
                 <ChevronDownIcon size={16} />
               </button>
-            ) : (
+            ) : undefined
+          }
+          center={
+            !hasCrews ? (
               <span className={styles.headerTitle}>일정</span>
-            )
+            ) : undefined
           }
           right={
             hasCrews ? (

--- a/apps/web/src/widgets/schedule-form/model/useScheduleForm.ts
+++ b/apps/web/src/widgets/schedule-form/model/useScheduleForm.ts
@@ -24,9 +24,12 @@ export function useScheduleForm(
 
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [isTimePickerOpen, setIsTimePickerOpen] = useState(false);
+  const [isPacePickerOpen, setIsPacePickerOpen] = useState(false);
   const [pendingAmPm, setPendingAmPm] = useState<'AM' | 'PM'>('AM');
   const [pendingHour, setPendingHour] = useState<number>(1);
   const [pendingMinute, setPendingMinute] = useState<number>(0);
+  const [pendingPaceMin, setPendingPaceMin] = useState<number>(5);
+  const [pendingPaceSec, setPendingPaceSec] = useState<number>(0);
   const [openSection, setOpenSection] = useState<string | null>(null);
   const [distanceError, setDistanceError] = useState(false);
   const [paceError, setPaceError] = useState(false);
@@ -154,6 +157,33 @@ export function useScheduleForm(
     [setValues]
   );
 
+  const openPacePicker = useCallback(() => {
+    const pace = valuesRef.current.pace;
+    if (pace != null) {
+      setPendingPaceMin(Math.floor(pace));
+      setPendingPaceSec(Math.round((pace - Math.floor(pace)) * 60));
+    } else {
+      setPendingPaceMin(5);
+      setPendingPaceSec(0);
+    }
+    setIsPacePickerOpen(true);
+  }, []);
+
+  const handlePacePickerClose = useCallback(
+    () => setIsPacePickerOpen(false),
+    []
+  );
+
+  const handlePaceConfirm = useCallback(
+    (min: number, sec: number) => {
+      const value = min + sec / 60;
+      setPaceError(value > PACE_MAX);
+      setValues({ pace: value });
+      setIsPacePickerOpen(false);
+    },
+    [setValues]
+  );
+
   const handleParticipantsChange = useCallback(
     (raw: string) => {
       const cleaned = raw.replace(/[^0-9]/g, '');
@@ -191,9 +221,17 @@ export function useScheduleForm(
     // 바텀시트 상태
     isCalendarOpen,
     isTimePickerOpen,
+    isPacePickerOpen,
     handleCalendarOpen,
     handleCalendarClose,
     handleTimePickerClose,
+    openPacePicker,
+    handlePacePickerClose,
+    handlePaceConfirm,
+    pendingPaceMin,
+    setPendingPaceMin,
+    pendingPaceSec,
+    setPendingPaceSec,
     // 아코디언
     openSection,
     toggleDatetime,

--- a/apps/web/src/widgets/schedule-form/styles/ScheduleForm.css.ts
+++ b/apps/web/src/widgets/schedule-form/styles/ScheduleForm.css.ts
@@ -387,7 +387,7 @@ export const accordionContent = style({
 export const accordionDivider = style({
   height: 1,
   width: '100%',
-  backgroundColor: vars.colors.gray10,
+  backgroundColor: vars.colors.gray20,
   flexShrink: 0,
 });
 

--- a/apps/web/src/widgets/schedule-form/styles/ScheduleForm.css.ts
+++ b/apps/web/src/widgets/schedule-form/styles/ScheduleForm.css.ts
@@ -166,7 +166,6 @@ export const unitInputWrapper = style({
   border: `0.5px solid ${vars.colors.gray20}`,
   padding: '10px 16px',
   backgroundColor: vars.colors.white,
-  cursor: 'pointer',
 });
 
 export const unitInputWrapperError = style({
@@ -179,8 +178,14 @@ export const unitInputWrapperError = style({
   border: `1px solid ${vars.colors.error}`,
   padding: '10px 16px',
   backgroundColor: vars.colors.white,
-  cursor: 'pointer',
 });
+
+export const paceInputButton = style([unitInputWrapper, { cursor: 'pointer' }]);
+
+export const paceInputButtonError = style([
+  unitInputWrapperError,
+  { cursor: 'pointer' },
+]);
 
 export const fixedWidthInputWrapper160 = style({
   width: 160,

--- a/apps/web/src/widgets/schedule-form/styles/ScheduleForm.css.ts
+++ b/apps/web/src/widgets/schedule-form/styles/ScheduleForm.css.ts
@@ -59,6 +59,7 @@ export const label = style([
     color: vars.colors.black,
     whiteSpace: 'nowrap',
     padding: '0 4px',
+    flexShrink: 0,
   },
 ]);
 
@@ -165,6 +166,7 @@ export const unitInputWrapper = style({
   border: `0.5px solid ${vars.colors.gray20}`,
   padding: '10px 16px',
   backgroundColor: vars.colors.white,
+  cursor: 'pointer',
 });
 
 export const unitInputWrapperError = style({
@@ -177,6 +179,17 @@ export const unitInputWrapperError = style({
   border: `1px solid ${vars.colors.error}`,
   padding: '10px 16px',
   backgroundColor: vars.colors.white,
+  cursor: 'pointer',
+});
+
+export const fixedWidthInputWrapper160 = style({
+  width: 160,
+  flexShrink: 0,
+});
+
+export const fixedWidthInputWrapper72 = style({
+  width: 72,
+  flexShrink: 0,
 });
 
 export const unitInputErrorMessage = style([
@@ -193,7 +206,8 @@ export const unitInputFieldWrapper = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 4,
-  width: '100%',
+  flexShrink: 1,
+  minWidth: 0,
 });
 
 export const unitInput = style([
@@ -211,6 +225,16 @@ export const unitInput = style([
         color: vars.colors.gray30,
       },
     },
+  },
+]);
+
+export const unitInputPlaceholder = style([
+  typography.body.b2,
+  {
+    flex: 1,
+    minWidth: 0,
+    color: vars.colors.gray30,
+    textAlign: 'right',
   },
 ]);
 
@@ -396,6 +420,16 @@ export const timePickerRow = style({
 });
 
 export const timePickerColumn = style({
+  flex: 1,
+});
+
+export const pacePickerRow = style({
+  display: 'flex',
+  width: '100%',
+  padding: '8px 0',
+});
+
+export const pacePickerColumn = style({
   flex: 1,
 });
 

--- a/apps/web/src/widgets/schedule-form/ui/ScheduleForm.tsx
+++ b/apps/web/src/widgets/schedule-form/ui/ScheduleForm.tsx
@@ -29,6 +29,16 @@ const minuteItems = Array.from({ length: 60 }, (_, i) => ({
   value: i,
 }));
 
+const paceMinItems = Array.from({ length: 20 }, (_, i) => ({
+  label: String(i + 1),
+  value: i + 1,
+}));
+
+const paceSecItems = [0, 10, 20, 30, 40, 50].map((s) => ({
+  label: String(s).padStart(2, '0'),
+  value: s,
+}));
+
 export interface ScheduleFormProps {
   formId: string;
   values: ScheduleFormValues;
@@ -49,9 +59,17 @@ export function ScheduleForm({
   const {
     isCalendarOpen,
     isTimePickerOpen,
+    isPacePickerOpen,
     handleCalendarOpen,
     handleCalendarClose,
     handleTimePickerClose,
+    openPacePicker,
+    handlePacePickerClose,
+    handlePaceConfirm,
+    pendingPaceMin,
+    setPendingPaceMin,
+    pendingPaceSec,
+    setPendingPaceSec,
     openSection,
     toggleDatetime,
     toggleLocation,
@@ -77,7 +95,6 @@ export function ScheduleForm({
     handleDateChange,
     handleDescriptionChange,
     handleDistanceChange,
-    handlePaceChange,
     handleParticipantsChange,
     dateDisplay,
     timeDisplay,
@@ -136,7 +153,7 @@ export function ScheduleForm({
           open={openSection === 'goal'}
           onToggle={toggleGoal}
           onDistanceChange={handleDistanceChange}
-          onPaceChange={handlePaceChange}
+          onPaceClick={openPacePicker}
         />
 
         <div className={styles.accordionDivider} />
@@ -176,6 +193,39 @@ export function ScheduleForm({
           value={values.date ? new Date(values.date + 'T00:00:00') : new Date()}
           onChange={handleDateChange}
         />
+      </BottomSheet>
+
+      <BottomSheet
+        isOpen={isPacePickerOpen}
+        onClose={handlePacePickerClose}
+        onOutsideClick={handlePacePickerClose}
+      >
+        <div className={styles.pacePickerRow}>
+          <div className={styles.pacePickerColumn}>
+            <WheelPicker
+              items={paceMinItems}
+              value={pendingPaceMin}
+              onChange={(v) => setPendingPaceMin(v as number)}
+            />
+          </div>
+          <div className={styles.pacePickerColumn}>
+            <WheelPicker
+              items={paceSecItems}
+              value={pendingPaceSec}
+              onChange={(v) => setPendingPaceSec(v as number)}
+            />
+          </div>
+        </div>
+        <div className={styles.timePickerFooter}>
+          <Button
+            type="button"
+            size="large"
+            state="active"
+            onClick={() => handlePaceConfirm(pendingPaceMin, pendingPaceSec)}
+          >
+            다음
+          </Button>
+        </div>
       </BottomSheet>
 
       <BottomSheet

--- a/apps/web/src/widgets/schedule-form/ui/ScheduleFormGoalSection.tsx
+++ b/apps/web/src/widgets/schedule-form/ui/ScheduleFormGoalSection.tsx
@@ -75,9 +75,7 @@ export const ScheduleFormGoalSection = memo(function ScheduleFormGoalSection({
             <button
               type="button"
               className={
-                paceError
-                  ? styles.unitInputWrapperError
-                  : styles.unitInputWrapper
+                paceError ? styles.paceInputButtonError : styles.paceInputButton
               }
               onClick={onPaceClick}
             >

--- a/apps/web/src/widgets/schedule-form/ui/ScheduleFormGoalSection.tsx
+++ b/apps/web/src/widgets/schedule-form/ui/ScheduleFormGoalSection.tsx
@@ -1,12 +1,11 @@
 import { FlagIcon } from '@azit/design-system/icon';
 import { memo } from 'react';
 
-import {
-  DISTANCE_MAX,
-  PACE_MAX,
-} from '@/widgets/schedule-form/model/scheduleForm';
+import { DISTANCE_MAX } from '@/widgets/schedule-form/model/scheduleForm';
 import * as styles from '@/widgets/schedule-form/styles/ScheduleForm.css';
 import { AccordionItem } from '@/widgets/schedule-form/ui/AccordionItem';
+
+import { formatPace } from '@/entities/schedule/lib/formatter';
 
 export interface ScheduleFormGoalSectionProps {
   distance: number | null;
@@ -17,7 +16,7 @@ export interface ScheduleFormGoalSectionProps {
   open: boolean;
   onToggle: () => void;
   onDistanceChange: (value: string) => void;
-  onPaceChange: (value: string) => void;
+  onPaceClick: () => void;
 }
 
 export const ScheduleFormGoalSection = memo(function ScheduleFormGoalSection({
@@ -29,7 +28,7 @@ export const ScheduleFormGoalSection = memo(function ScheduleFormGoalSection({
   open,
   onToggle,
   onDistanceChange,
-  onPaceChange,
+  onPaceClick,
 }: ScheduleFormGoalSectionProps) {
   return (
     <AccordionItem
@@ -44,7 +43,7 @@ export const ScheduleFormGoalSection = memo(function ScheduleFormGoalSection({
           <label className={styles.label} htmlFor="schedule-distance">
             목표 거리
           </label>
-          <div className={styles.unitInputFieldWrapper}>
+          <div className={styles.fixedWidthInputWrapper160}>
             <div
               className={
                 distanceError
@@ -71,33 +70,25 @@ export const ScheduleFormGoalSection = memo(function ScheduleFormGoalSection({
           </div>
         </div>
         <div className={styles.horizontalSection}>
-          <label className={styles.label} htmlFor="schedule-pace">
-            목표 페이스
-          </label>
-          <div className={styles.unitInputFieldWrapper}>
-            <div
+          <span className={styles.label}>목표 페이스</span>
+          <div className={styles.fixedWidthInputWrapper72}>
+            <button
+              type="button"
               className={
                 paceError
                   ? styles.unitInputWrapperError
                   : styles.unitInputWrapper
               }
+              onClick={onPaceClick}
             >
-              <input
-                id="schedule-pace"
-                type="text"
-                inputMode="numeric"
-                className={styles.unitInput}
-                value={pace ?? ''}
-                onChange={(e) => onPaceChange(e.target.value)}
-                placeholder="0"
-              />
-              <span className={styles.unitSuffix}>분/km</span>
-            </div>
-            {paceError && (
-              <p className={styles.unitInputErrorMessage}>
-                최대 값 : {PACE_MAX}
-              </p>
-            )}
+              <span
+                className={
+                  pace != null ? styles.unitInput : styles.unitInputPlaceholder
+                }
+              >
+                {pace != null ? formatPace(pace) : '5\'00"'}
+              </span>
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🛠️ 변경 사항

- [ ] UI 수정 (Design)
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug)
- [ ] 리팩토링 (Refactor)
- [ ] 성능 개선 (Performance)
- [ ] 테스트 추가 (Chore)
- [ ] 기타:

### 세부 변경 내용

- 일정 페이지 헤더에서 크루 미가입 시 "일정" 텍스트를 left → center prop으로 이동하여 중앙 정렬
- 목표 페이스 입력 방식을 텍스트 입력 → 휠 피커 바텀시트로 변경
- `useScheduleForm`에 페이스 피커 상태 및 핸들러(`isPacePickerOpen`, `openPacePicker`, `handlePaceConfirm` 등) 추가
- `ScheduleFormGoalSection`의 페이스 필드를 `<input>` → `<button>` 클릭 트리거로 교체
- 페이스 값 표시에 `formatPace` 포매터 적용
- 스타일: `fixedWidthInputWrapper160/72`, `unitInputPlaceholder`, `pacePickerRow/Column` 등 스타일 추가
***

## 🔍 관련 이슈

- close #215

---

## 📸 스크린샷 / GIF (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## ⚠️ 주의 사항 / 리뷰 포인트

-
***

## 🔄 연관 작업

-
-